### PR TITLE
Add 'reporter' as command option #8

### DIFF
--- a/Sources/IBLinterKit/Reporters/JSONReporter.swift
+++ b/Sources/IBLinterKit/Reporters/JSONReporter.swift
@@ -11,15 +11,16 @@ struct JSONReporter: Reporter {
 
     static let identifier: String = "json"
 
-    func report(violations: [Violation]) {
+    static func generateReport(violations: [Violation]) -> String {
         let dictionary = violations.map(toJSON)
         let json = try! JSONSerialization.data(withJSONObject: dictionary, options: .prettyPrinted)
         if let jsonString = String(data: json, encoding: .utf8) {
-            print(jsonString)
+            return jsonString
         }
+        return ""
     }
 
-    func toJSON(violation: Violation) -> [String: Any] {
+    static func toJSON(violation: Violation) -> [String: Any] {
         return [
             "file": violation.interfaceBuilderFile.pathString,
             "level": violation.level.rawValue,

--- a/Sources/IBLinterKit/Reporters/Reporter.swift
+++ b/Sources/IBLinterKit/Reporters/Reporter.swift
@@ -8,19 +8,19 @@
 protocol Reporter {
     static var identifier: String { get }
 
-    func report(violations: [Violation])
+    static func generateReport(violations: [Violation]) -> String
 }
 
 struct Reporters {
 
-    static func reporter(from config: Config) -> Reporter {
-        switch config.reporter {
+    static func reporter(from reporter: String) -> Reporter.Type {
+        switch reporter {
         case XcodeReporter.identifier:
-            return XcodeReporter()
+            return XcodeReporter.self
         case JSONReporter.identifier:
-            return JSONReporter()
+            return JSONReporter.self
         default:
-            fatalError("no reporter with identifier '\(config.reporter) available'")
+            fatalError("no reporter with identifier '\(reporter) available'")
         }
     }
 }

--- a/Sources/IBLinterKit/Reporters/XcodeReporter.swift
+++ b/Sources/IBLinterKit/Reporters/XcodeReporter.swift
@@ -9,11 +9,11 @@ struct XcodeReporter: Reporter {
 
     static let identifier: String = "xcode"
 
-    func report(violations: [Violation]) {
-        violations.map(report).forEach { print($0) }
+    static func generateReport(violations: [Violation]) -> String  {
+        return violations.map(report).joined(separator: "\n")
     }
 
-    func report(violation: Violation) -> String {
+    static func report(violation: Violation) -> String {
         return [
             "\(violation.interfaceBuilderFile.pathString):",
             ":: ",

--- a/Tests/IBLinterKitTest/ReportersTest.swift
+++ b/Tests/IBLinterKitTest/ReportersTest.swift
@@ -12,7 +12,7 @@ import XCTest
 class ReportersTest: XCTestCase {
 
     func testJSONReporter() {
-        let reporter = JSONReporter()
+        let reporter = JSONReporter.self
 
         let path = "Tests/IBLinterKitTest/Resources/ViewTest.xib"
         let violation = Violation(interfaceBuilderFile: try! XibFile(path: path),


### PR DESCRIPTION
Put report in string before printing it (allowing later to output result in file)
Do not create reporter object by using static