### PR TITLE
Add `EmojiReporter`. Fix #10

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,13 @@
+included:
+- Sources
+line_length:
+  warning: 165
+  ignores_comments: true
+large_tuple:
+  warning: 3
+disabled_rules:
+  - colon
+  - identifier_name
+  - type_name
+  - cyclomatic_complexity
+  - pattern_matching_keywords

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/Carthage/Commandant.git",
         "state": {
           "branch": "master",
-          "revision": "ab5f20d3e845dc3845eb4c79a4bd8d5ac8af5e1c",
+          "revision": "d0d629095653f8e1f2933449fe25ff653191eaf9",
           "version": null
         }
       },
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "22800b0954c89344bb8c87f8ab93378076716fb7",
-          "version": "7.0.3"
+          "revision": "21f4fed2052cea480f5f1d2044d45aa25fdfb988",
+          "version": "7.1.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "0ff81f2c665b4381f526bd656f8708dd52a9ea2f",
-          "version": "1.2.0"
+          "revision": "3e3023569c8d4c4a0d000f58db765df53041117f",
+          "version": "1.3.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
         "state": {
           "branch": null,
-          "revision": "12496b370363034ccc919e1d72a99b9970b4941e",
-          "version": "4.2.5"
+          "revision": "17d992beb3aaeda403fd35f8d5e70ab1a8124f35",
+          "version": "4.6.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "95f45caf07472ec78223ebada45255086a85b01a",
-          "version": "0.5.0"
+          "revision": "6652aa7b793d3c8a075db0614acb575fcaecf457",
+          "version": "0.7.0"
         }
       }
     ]

--- a/Sources/IBLinterCore/Extension/Glob.swift
+++ b/Sources/IBLinterCore/Extension/Glob.swift
@@ -73,7 +73,6 @@ public func glob(pattern: String) -> [URL] {
     return results.map(URL.init(fileURLWithPath: ))
 }
 
-
 private func executeGlob(pattern: UnsafePointer<CChar>, gt: UnsafeMutablePointer<glob_t>) -> Bool {
     return 0 == glob(pattern, globFlags, nil, gt)
 }

--- a/Sources/IBLinterCore/Extension/SWXMLHash+Extension.swift
+++ b/Sources/IBLinterCore/Extension/SWXMLHash+Extension.swift
@@ -38,4 +38,3 @@ extension String: XMLAttributeDecodable {}
 extension Int: XMLAttributeDecodable {}
 extension Float: XMLAttributeDecodable {}
 extension Bool: XMLAttributeDecodable {}
-

--- a/Sources/IBLinterCore/Models/Views/AnyView.swift
+++ b/Sources/IBLinterCore/Models/Views/AnyView.swift
@@ -145,7 +145,7 @@ public struct Constraint: XMLDecodable, KeyDecodable {
             }
         }
 
-        public static func ==(lhs: LayoutAttribute, rhs: LayoutAttribute) -> Bool {
+        public static func == (lhs: LayoutAttribute, rhs: LayoutAttribute) -> Bool {
             switch (lhs, rhs) {
             case (.left, .left), (.right, .right), (.top, .top), (.bottom, .bottom),
                  (.leading, .leading), (.trailing, .trailing), (.width, .width),

--- a/Sources/IBLinterCore/Models/Views/Toolbar.swift
+++ b/Sources/IBLinterCore/Models/Views/Toolbar.swift
@@ -25,7 +25,6 @@ public struct Toolbar: XMLDecodable, ViewProtocol, KeyDecodable {
     public let translatesAutoresizingMaskIntoConstraints: Bool?
     public let userInteractionEnabled: Bool?
 
-
     public struct BarButtonItem: XMLDecodable, KeyDecodable {
         public let id: String
         public let style: String?

--- a/Sources/IBLinterKit/Config.swift
+++ b/Sources/IBLinterKit/Config.swift
@@ -30,7 +30,7 @@ public struct Config: Codable {
         excluded = []
         reporter = "xcode"
     }
-    
+
     init(disabledRules: [String], enabledRules: [String], excluded: [String], reporter: String) {
         self.disabledRules = disabledRules
         self.enabledRules = enabledRules

--- a/Sources/IBLinterKit/Reporters/EmojiReporter.swift
+++ b/Sources/IBLinterKit/Reporters/EmojiReporter.swift
@@ -26,13 +26,6 @@ struct EmojiReporter: Reporter {
         return lines.joined(separator: "\n")
     }
 
-    fileprivate static func dictionary(for violation: Violation) -> [String: Any] {
-        return [
-            "file": violation.interfaceBuilderFile.pathString,
-            "level": violation.level.rawValue,
-            "message": violation.message
-        ]
-    }
 }
 
 extension Array {

--- a/Sources/IBLinterKit/Reporters/EmojiReporter.swift
+++ b/Sources/IBLinterKit/Reporters/EmojiReporter.swift
@@ -1,0 +1,47 @@
+//
+//  EmojiReporter.swift
+//  IBLinterKit
+//
+//  Created by phimage on 20/04/2018.
+//
+
+import Foundation
+
+struct EmojiReporter: Reporter {
+    public static let identifier = "emoji"
+
+    public static func generateReport(violations: [Violation]) -> String {
+        return violations.group { violation in
+            violation.interfaceBuilderFile.pathString
+            }.map(report).joined(separator: "\n")
+    }
+
+    private static func report(for file: String, with violations: [Violation]) -> String {
+        let lines = [file] + violations.sorted(by: { lhs, rhs in
+            return lhs.level > rhs.level
+        }).map { violation in
+            let emoji = (violation.level == .error) ? "⛔️" : "⚠️"
+            return "\(emoji) \(violation.message)"
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    fileprivate static func dictionary(for violation: Violation) -> [String: Any] {
+        return [
+            "file": violation.interfaceBuilderFile.pathString,
+            "level": violation.level.rawValue,
+            "message": violation.message
+        ]
+    }
+}
+
+extension Array {
+    func group<U: Hashable>(by transform: (Element) -> U) -> [U: [Element]] {
+        return reduce([:]) { dictionary, element in
+            var dictionary = dictionary
+            let key = transform(element)
+            dictionary[key] = (dictionary[key] ?? []) + [element]
+            return dictionary
+        }
+    }
+}

--- a/Sources/IBLinterKit/Reporters/JSONReporter.swift
+++ b/Sources/IBLinterKit/Reporters/JSONReporter.swift
@@ -13,8 +13,8 @@ struct JSONReporter: Reporter {
 
     static func generateReport(violations: [Violation]) -> String {
         let dictionary = violations.map(toJSON)
-        let json = try! JSONSerialization.data(withJSONObject: dictionary, options: .prettyPrinted)
-        if let jsonString = String(data: json, encoding: .utf8) {
+        if let json = try? JSONSerialization.data(withJSONObject: dictionary, options: .prettyPrinted),
+            let jsonString = String(data: json, encoding: .utf8) {
             return jsonString
         }
         return ""
@@ -28,4 +28,3 @@ struct JSONReporter: Reporter {
         ]
     }
 }
-

--- a/Sources/IBLinterKit/Reporters/Reporter.swift
+++ b/Sources/IBLinterKit/Reporters/Reporter.swift
@@ -19,6 +19,8 @@ struct Reporters {
             return XcodeReporter.self
         case JSONReporter.identifier:
             return JSONReporter.self
+        case EmojiReporter.identifier:
+            return EmojiReporter.self
         default:
             fatalError("no reporter with identifier '\(reporter) available'")
         }

--- a/Sources/IBLinterKit/Reporters/XcodeReporter.swift
+++ b/Sources/IBLinterKit/Reporters/XcodeReporter.swift
@@ -9,7 +9,7 @@ struct XcodeReporter: Reporter {
 
     static let identifier: String = "xcode"
 
-    static func generateReport(violations: [Violation]) -> String  {
+    static func generateReport(violations: [Violation]) -> String {
         return violations.map(report).joined(separator: "\n")
     }
 
@@ -18,7 +18,7 @@ struct XcodeReporter: Reporter {
             "\(violation.interfaceBuilderFile.pathString):",
             ":: ",
             "\(violation.level.rawValue): ",
-            violation.message,
+            violation.message
             ].joined()
 
     }

--- a/Sources/IBLinterKit/Rules/DuplicateConstraintRule.swift
+++ b/Sources/IBLinterKit/Rules/DuplicateConstraintRule.swift
@@ -27,6 +27,7 @@ extension Rules {
 
         private func validate(for view: ViewProtocol, file: InterfaceBuilderFile) -> [Violation] {
             return duplicateConstraints(for: view.constraints ?? []).map {
+                // swiftlint:disable:next line_length
                 let message = "duplicate constraint \($0.id) (firstItem: \($0.firstItem ?? "nil") attribute: \($0.firstAttribute.map(String.init(describing: )) ?? "nil") secondItem: \($0.secondItem ?? "nil") attribute: \($0.secondAttribute.map(String.init(describing: )) ?? "nil"))"
                 return Violation(
                     interfaceBuilderFile: file,

--- a/Sources/IBLinterKit/Rules/Rule.swift
+++ b/Sources/IBLinterKit/Rules/Rule.swift
@@ -39,7 +39,7 @@ public struct Rules {
         var identifiers = Set(defaultRules.map({ $0.identifier }))
         identifiers.subtract(config.disabledRules)
         identifiers.formUnion(config.enabledRules)
-        
+
         return allRules.filter { identifiers.contains($0.identifier) }.map { $0.init() }
     }
 }

--- a/Sources/IBLinterKit/Violation.swift
+++ b/Sources/IBLinterKit/Violation.swift
@@ -13,8 +13,12 @@ public struct Violation {
     let message: String
     let level: Level
 
-    enum Level: String {
+    enum Level: String, Comparable {
         case warning
         case error
+
+        static func < (lhs: Violation.Level, rhs: Violation.Level) -> Bool {
+            return lhs == .warning && rhs == .error
+        }
     }
 }

--- a/Sources/iblinter/main.swift
+++ b/Sources/iblinter/main.swift
@@ -2,4 +2,3 @@ import IBLinterKit
 
 let app = App.init()
 app.main()
-

--- a/Tests/IBLinterKitTest/InterfaceBuilderParserTest.swift
+++ b/Tests/IBLinterKitTest/InterfaceBuilderParserTest.swift
@@ -18,7 +18,7 @@ class InterfaceBuilderParserTest: XCTestCase {
         let document = try parser.parseStoryboard(xml: xmlString(fileName: "ViewControllerTest.storyboard"))
         let viewController = document.scenes![0].viewController!.viewController as! ViewController
         XCTAssertEqual(viewController.id, "uo8-pZ-S8b")
-        
+
         let view = viewController.view!
         XCTAssertEqual(view.id, "EHN-qE-V0Y")
         XCTAssertEqual(view.contentMode, "scaleToFill")

--- a/Tests/IBLinterKitTest/RuleTest.swift
+++ b/Tests/IBLinterKitTest/RuleTest.swift
@@ -24,7 +24,7 @@ class RuleTest: XCTestCase {
         let violations = try! rule.validate(xib: XibFile.init(path: path))
         XCTAssertEqual(violations.count, 2)
     }
-    
+
     func testDefaultEnabledRules() {
         let defaultEnabledRules = Rules.defaultRules.map({ $0.identifier })
         let config = Config(disabledRules: [], enabledRules: [], excluded: [], reporter: "xcode")
@@ -32,7 +32,7 @@ class RuleTest: XCTestCase {
         XCTAssertEqual(Set(rules.map({ type(of:$0).identifier })), Set(defaultEnabledRules))
         XCTAssertEqual(rules.count, defaultEnabledRules.count)
     }
-    
+
     func testDisableDefaultEnabledRules() {
         let defaultEnabledRules = Rules.defaultRules.map({ $0.identifier })
         let config = Config(disabledRules: defaultEnabledRules, enabledRules: [], excluded: [], reporter: "xcode")
@@ -40,7 +40,7 @@ class RuleTest: XCTestCase {
         XCTAssertEqual(Set(rules.map({ type(of:$0).identifier })), Set())
         XCTAssertEqual(rules.count, 0)
     }
-    
+
     func testDuplicatedEnabledRules() {
         let defaultEnabledRules = Rules.defaultRules.map({ $0.identifier })
         let config = Config(disabledRules: [], enabledRules: defaultEnabledRules, excluded: [], reporter: "xcode")
@@ -49,4 +49,3 @@ class RuleTest: XCTestCase {
         XCTAssertEqual(rules.count, defaultEnabledRules.count)
     }
 }
-


### PR DESCRIPTION
Name inspired from swiftlint

+ Fix swiftlint  warnings (whitespaces, blank lines)
```
iblinter --path Tests/IBLinterKitTest --reporter emoji
```
```
/Users/phimage/Dev/IBLinter/Tests/IBLinterKitTest/Resources/MacXibTest.xib is mac format and skipped.
/Users/phimage/Dev/IBLinter/Tests/IBLinterKitTest/Resources/ConstraintTest.storyboard
⛔️ custom class name 'ViewController' should be 'ConstraintTest' 
/Users/phimage/Dev/IBLinter/Tests/IBLinterKitTest/Resources/DuplicateConstraint.xib
⚠️ duplicate constraint Prh-uf-M6D (firstItem: ItZ-vi-bgh attribute: top secondItem: vUN-kp-3ea attribute: top)
⚠️ duplicate constraint aEU-56-OK8 (firstItem: ItZ-vi-bgh attribute: centerX secondItem: iN0-l3-epB attribute: centerX)
/Users/phimage/Dev/IBLinter/Tests/IBLinterKitTest/Resources/ViewControllerTest.storyboard
⛔️ custom class name 'ViewController' should be 'ViewControllerTest' 
```
