### PR TITLE
Update Commandant to use version instead of branch for compatibility with other packages using Commandant

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "Commandant",
         "repositoryURL": "https://github.com/Carthage/Commandant.git",
         "state": {
-          "branch": "master",
-          "revision": "d69a33a7c4fb7d6e389584106001963ae3db5209",
-          "version": null
+          "branch": null,
+          "revision": "07cad52573bad19d95844035bf0b25acddf6b0f6",
+          "version": "0.15.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/IBDecodable/IBDecodable.git", .branch("master")),
-        .package(url: "https://github.com/Carthage/Commandant.git", .branch("master")),
+        .package(url: "https://github.com/Carthage/Commandant.git", from: "0.15.0"),
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.21.1"),
         .package(url: "https://github.com/xcodeswift/xcproj.git", from: "4.3.0"),
         .package(url: "https://github.com/JohnSundell/Marathon.git", from: "3.0.0")


### PR DESCRIPTION
In the current setup, if `IBLinter` is used in a project via SPM with other tools that uses `Commandant` (for example [`SwiftLint`](https://github.com/realm/SwiftLint)):
```swift
// swift-tools-version:4.2
import PackageDescription

let package = Package(
    name: "App",
    dependencies: [
      .package(url: "https://github.com/Realm/SwiftLint", from: "0.28.1"),
      .package(url: "https://github.com/stephanecopin/IBLinter", .from("0.4.11")),
    ]
)

```
The `swift build` command will fail with the following error:
```shell
error: the package iblinter[https://github.com/IBDecodable/IBLinter] @ 0.4.11 contains incompatible dependencies:
    ibdecodable[https://github.com/IBDecodable/IBDecodable.git] @ master
    commandant[https://github.com/Carthage/Commandant.git] @ master
```
This PR fixes the issue by specifying the latest (as of writing this) version for `Commandant`, `0.15.0`.

I didn't touch `IBDecodable` as it wasn't an issue for me, but let me know if I should also update it and pin the version to `0.0.2`.