### PR TITLE
Use Base Class Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ Alternatively, if you've installed IBLinter via CocoaPods the script should look
 | `enable_autolayout`            | Force to use `useAutolayout` option                                            |
 | `duplicate_constraint`         | Display warning when view has duplicated constraint.                           |
 | `storyboard_viewcontroller_id` | Check that Storyboard ID same as ViewController class name.                    |
-| `image_resources`              | Check if image resources are valid.                                             |
+| `image_resources`              | Check if image resources are valid.                                            |
 | `custom_module`                | Check if custom class match custom module by `custom_module_rule` config.      |
+| `use_base_class`               | Check if custom class is in base classes by `use_base_class_rule` config.      |
 
 
 Pull requests are encouraged.
@@ -91,8 +92,9 @@ You can configure IBLinter by adding a `.iblinter.yml` file from project root di
 | `enabled_rules`      | Enabled rules id.           |
 | `disabled_rules`     | Disabled rules id.          |
 | `excluded`           | Path to ignore for lint.    |
-| `included`           | Path to include for lint.    |
+| `included`           | Path to include for lint.   |
 | `custom_module_rule` | Custom module rule configs. |
+| `use_base_class_rule`| Use base class rule configs.|
 
 ### CustomModuleConfig
 
@@ -103,6 +105,15 @@ You can configure `custom_module` rule by `CustomModuleConfig` list.
 | `module`   | Module name.                                                                 |
 | `included` | Path to `*.swift` classes of the module for `custom_module` lint.            |
 | `excluded` | Path to ignore for `*.swift` classes of the module for `custom_module` lint. |
+
+### UseBaseClassConfig
+
+You can configure `use_base_class` rule by `UseBaseClassConfig` list.
+
+| key               | description                        |
+|:------------------|:---------------------------------- |
+| `element_class`   | Element class name.                |
+| `base_classes`    | Base classes of the element class. |
 
 
 ```yaml
@@ -121,4 +132,9 @@ custom_module_rule:
       - UIComponents/Classes
     excluded:
       - UIComponents/Classes/Config/Generated
+use_base_class_rule:
+  - element_class: UILabel
+    base_classes:
+      - PrimaryLabel
+      - SecondaryLabel
 ```

--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ You can configure `custom_module` rule by `CustomModuleConfig` list.
 
 You can configure `use_base_class` rule by `UseBaseClassConfig` list.
 
-| key               | description                            |
-|:------------------|:-------------------------------------- |
-| `element_class`   | Element class name.                    |
-| `base_classes`    | Base classes of the element class[^1]. |
+| key               | description                        |
+|:------------------|:---------------------------------- |
+| `element_class`   | Element class name.                |
+| `base_classes`    | Base classes of the element class. |
 
-[^1]: UseBaseClassRule does not work for classes that inherit base class. You need to add all classes to `base_classes` to check.
+**Note:** UseBaseClassRule does not work for classes that inherit base class. You need to add all classes to `base_classes` to check.
 
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -110,10 +110,12 @@ You can configure `custom_module` rule by `CustomModuleConfig` list.
 
 You can configure `use_base_class` rule by `UseBaseClassConfig` list.
 
-| key               | description                        |
-|:------------------|:---------------------------------- |
-| `element_class`   | Element class name.                |
-| `base_classes`    | Base classes of the element class. |
+| key               | description                            |
+|:------------------|:-------------------------------------- |
+| `element_class`   | Element class name.                    |
+| `base_classes`    | Base classes of the element class[^1]. |
+
+[^1]: UseBaseClassRule does not work for classes that inherit base class. You need to add all classes to `base_classes` to check.
 
 
 ```yaml

--- a/Sources/IBLinterKit/BaseClassConfig.swift
+++ b/Sources/IBLinterKit/BaseClassConfig.swift
@@ -1,0 +1,36 @@
+//
+//  BaseClassConfig.swift
+//  AEXML
+//
+//  Created by masamichi on 2019/03/11.
+//
+
+import Foundation
+
+public struct BaseClassConfig: Codable {
+    public let elementClass: String
+    public let baseClasses: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case elementClass = "element_class"
+        case baseClasses = "base_classes"
+    }
+
+    public static let `default` = BaseClassConfig.init()
+
+    private init() {
+        elementClass = ""
+        baseClasses = []
+    }
+
+    init(elementClass: String, baseClasses: [String]) {
+        self.elementClass = elementClass
+        self.baseClasses = baseClasses
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        elementClass = try container.decodeIfPresent(Optional<String>.self, forKey: .elementClass).flatMap { $0 } ?? ""
+        baseClasses = try container.decodeIfPresent(Optional<[String]>.self, forKey: .baseClasses)?.flatMap { $0 } ?? []
+    }
+}

--- a/Sources/IBLinterKit/Config.swift
+++ b/Sources/IBLinterKit/Config.swift
@@ -14,7 +14,7 @@ public struct Config: Codable {
     public let excluded: [String]
     public let included: [String]
     public let customModuleRule: [CustomModuleConfig]
-    public let baseClassRule: [UseBaseClassConfig]
+    public let useBaseClassRule: [UseBaseClassConfig]
     public let reporter: String
 
     enum CodingKeys: String, CodingKey {
@@ -23,7 +23,7 @@ public struct Config: Codable {
         case excluded = "excluded"
         case included = "included"
         case customModuleRule = "custom_module_rule"
-        case baseClassRule = "use_base_class_rule"
+        case useBaseClassRule = "use_base_class_rule"
         case reporter = "reporter"
     }
 
@@ -36,7 +36,7 @@ public struct Config: Codable {
         excluded = []
         included = []
         customModuleRule = []
-        baseClassRule = []
+        useBaseClassRule = []
         reporter = "xcode"
     }
 
@@ -46,7 +46,7 @@ public struct Config: Codable {
         self.excluded = excluded
         self.included = included
         self.customModuleRule = customModuleRule
-        self.baseClassRule = baseClassRule
+        self.useBaseClassRule = baseClassRule
         self.reporter = reporter
     }
 
@@ -57,7 +57,7 @@ public struct Config: Codable {
         excluded = try container.decodeIfPresent(Optional<[String]>.self, forKey: .excluded).flatMap { $0 } ?? []
         included = try container.decodeIfPresent(Optional<[String]>.self, forKey: .included).flatMap { $0 } ?? []
         customModuleRule = try container.decodeIfPresent(Optional<[CustomModuleConfig]>.self, forKey: .customModuleRule).flatMap { $0 } ?? []
-        baseClassRule = try container.decodeIfPresent(Optional<[UseBaseClassConfig]>.self, forKey: .baseClassRule)?.flatMap { $0 } ?? []
+        useBaseClassRule = try container.decodeIfPresent(Optional<[UseBaseClassConfig]>.self, forKey: .useBaseClassRule)?.flatMap { $0 } ?? []
         reporter = try container.decodeIfPresent(Optional<String>.self, forKey: .reporter).flatMap { $0 } ?? "xcode"
     }
 

--- a/Sources/IBLinterKit/Config.swift
+++ b/Sources/IBLinterKit/Config.swift
@@ -14,7 +14,7 @@ public struct Config: Codable {
     public let excluded: [String]
     public let included: [String]
     public let customModuleRule: [CustomModuleConfig]
-    public let baseClassRule: [BaseClassConfig]
+    public let baseClassRule: [UseBaseClassConfig]
     public let reporter: String
 
     enum CodingKeys: String, CodingKey {
@@ -23,7 +23,7 @@ public struct Config: Codable {
         case excluded = "excluded"
         case included = "included"
         case customModuleRule = "custom_module_rule"
-        case baseClassRule = "base_class_rule"
+        case baseClassRule = "use_base_class_rule"
         case reporter = "reporter"
     }
 
@@ -40,7 +40,7 @@ public struct Config: Codable {
         reporter = "xcode"
     }
 
-    init(disabledRules: [String], enabledRules: [String], excluded: [String], included: [String], customModuleRule: [CustomModuleConfig], baseClassRule: [BaseClassConfig], reporter: String) {
+    init(disabledRules: [String], enabledRules: [String], excluded: [String], included: [String], customModuleRule: [CustomModuleConfig], baseClassRule: [UseBaseClassConfig], reporter: String) {
         self.disabledRules = disabledRules
         self.enabledRules = enabledRules
         self.excluded = excluded
@@ -57,7 +57,7 @@ public struct Config: Codable {
         excluded = try container.decodeIfPresent(Optional<[String]>.self, forKey: .excluded).flatMap { $0 } ?? []
         included = try container.decodeIfPresent(Optional<[String]>.self, forKey: .included).flatMap { $0 } ?? []
         customModuleRule = try container.decodeIfPresent(Optional<[CustomModuleConfig]>.self, forKey: .customModuleRule).flatMap { $0 } ?? []
-        baseClassRule = try container.decodeIfPresent(Optional<[BaseClassConfig]>.self, forKey: .baseClassRule)?.flatMap { $0 } ?? []
+        baseClassRule = try container.decodeIfPresent(Optional<[UseBaseClassConfig]>.self, forKey: .baseClassRule)?.flatMap { $0 } ?? []
         reporter = try container.decodeIfPresent(Optional<String>.self, forKey: .reporter).flatMap { $0 } ?? "xcode"
     }
 

--- a/Sources/IBLinterKit/Config.swift
+++ b/Sources/IBLinterKit/Config.swift
@@ -14,6 +14,7 @@ public struct Config: Codable {
     public let excluded: [String]
     public let included: [String]
     public let customModuleRule: [CustomModuleConfig]
+    public let baseClassRule: [BaseClassConfig]
     public let reporter: String
 
     enum CodingKeys: String, CodingKey {
@@ -22,6 +23,7 @@ public struct Config: Codable {
         case excluded = "excluded"
         case included = "included"
         case customModuleRule = "custom_module_rule"
+        case baseClassRule = "base_class_rule"
         case reporter = "reporter"
     }
 
@@ -34,15 +36,17 @@ public struct Config: Codable {
         excluded = []
         included = []
         customModuleRule = []
+        baseClassRule = []
         reporter = "xcode"
     }
 
-    init(disabledRules: [String], enabledRules: [String], excluded: [String], included: [String], customModuleRule: [CustomModuleConfig], reporter: String) {
+    init(disabledRules: [String], enabledRules: [String], excluded: [String], included: [String], customModuleRule: [CustomModuleConfig], baseClassRule: [BaseClassConfig], reporter: String) {
         self.disabledRules = disabledRules
         self.enabledRules = enabledRules
         self.excluded = excluded
         self.included = included
         self.customModuleRule = customModuleRule
+        self.baseClassRule = baseClassRule
         self.reporter = reporter
     }
 
@@ -53,6 +57,7 @@ public struct Config: Codable {
         excluded = try container.decodeIfPresent(Optional<[String]>.self, forKey: .excluded).flatMap { $0 } ?? []
         included = try container.decodeIfPresent(Optional<[String]>.self, forKey: .included).flatMap { $0 } ?? []
         customModuleRule = try container.decodeIfPresent(Optional<[CustomModuleConfig]>.self, forKey: .customModuleRule).flatMap { $0 } ?? []
+        baseClassRule = try container.decodeIfPresent(Optional<[BaseClassConfig]>.self, forKey: .baseClassRule)?.flatMap { $0 } ?? []
         reporter = try container.decodeIfPresent(Optional<String>.self, forKey: .reporter).flatMap { $0 } ?? "xcode"
     }
 

--- a/Sources/IBLinterKit/Rules/Rule.swift
+++ b/Sources/IBLinterKit/Rules/Rule.swift
@@ -26,6 +26,7 @@ public struct Rules {
             StoryboardViewControllerId.self,
             ImageResourcesRule.self,
             CustomModuleRule.self,
+            UseBaseClassRule.self,
             AmbiguousViewRule.self,
         ]
     }()

--- a/Sources/IBLinterKit/Rules/UseBaseClassRule.swift
+++ b/Sources/IBLinterKit/Rules/UseBaseClassRule.swift
@@ -34,7 +34,7 @@ extension Rules {
         private var baseClasses: [String: [String]] = [:]
 
         public init(context: Context) {
-            for baseClassConfig in context.config.baseClassRule {
+            for baseClassConfig in context.config.useBaseClassRule {
                 self.baseClasses[baseClassConfig.elementClass] = baseClassConfig.baseClasses
             }
         }

--- a/Sources/IBLinterKit/Rules/UseBaseClassRule.swift
+++ b/Sources/IBLinterKit/Rules/UseBaseClassRule.swift
@@ -54,12 +54,12 @@ extension Rules {
             let violation: [Violation] = {
                 guard let baseClassesForElement = baseClasses[view.elementClass] else { return [] }
                 guard let customClass = view.customClass else {
-                    let message = "CustomClass is not set to this view"
+                    let message = "CustomClass is not set to \(view.elementClass) (\(view.id)) "
                     return [Violation(pathString: file.pathString, message: message, level: .warning)]
                 }
 
                 if !baseClassesForElement.contains(customClass) {
-                    let message = "CustomClass is not equal to the BaseClass"
+                    let message = "\(customClass) (\(view.id) is not contained in the BaseClasses"
                     return [Violation(pathString: file.pathString, message: message, level: .warning)]
                 }
                 return []

--- a/Sources/IBLinterKit/Rules/UseBaseClassRule.swift
+++ b/Sources/IBLinterKit/Rules/UseBaseClassRule.swift
@@ -1,0 +1,50 @@
+//
+//  UseBaseClassRule.swift
+//  IBLinterKit
+//
+//  Created by masamichi on 2019/03/07.
+//
+
+import Foundation
+import IBDecodable
+
+private extension XibFile {
+    var fileExtension: String {
+        return URL.init(fileURLWithPath: pathString).pathExtension
+    }
+    var fileNameWithoutExtension: String {
+        return fileName.replacingOccurrences(of: ".\(fileExtension)", with: "")
+    }
+}
+
+private extension StoryboardFile {
+    var fileExtension: String {
+        return URL.init(fileURLWithPath: pathString).pathExtension
+    }
+    var fileNameWithoutExtension: String {
+        return fileName.replacingOccurrences(of: ".\(fileExtension)", with: "")
+    }
+}
+
+extension Rules {
+    public struct UseBaseClassRule: Rule {
+        public init(context: Context) {}
+
+        public static var identifier: String = "use_base_class"
+
+        public func validate(storyboard: StoryboardFile) -> [Violation] {
+            guard let scenes = storyboard.document.scenes else { return [] }
+            let views = scenes.compactMap { $0.viewController?.viewController.rootView }
+            return views.flatMap { validate(for: $0, file: storyboard, fileNameWithoutExtension: storyboard.fileNameWithoutExtension) }
+        }
+
+        public func validate(xib: XibFile) -> [Violation] {
+            guard let views = xib.document.views else { return [] }
+            return views.flatMap { validate(for: $0.view, file: xib, fileNameWithoutExtension: xib.fileNameWithoutExtension) }
+        }
+
+        private func validate<T: InterfaceBuilderFile>(for view: ViewProtocol, file: T, fileNameWithoutExtension: String) -> [Violation] {
+            return []
+        }
+    }
+}

--- a/Sources/IBLinterKit/Rules/UseBaseClassRule.swift
+++ b/Sources/IBLinterKit/Rules/UseBaseClassRule.swift
@@ -8,24 +8,6 @@
 import Foundation
 import IBDecodable
 
-private extension XibFile {
-    var fileExtension: String {
-        return URL.init(fileURLWithPath: pathString).pathExtension
-    }
-    var fileNameWithoutExtension: String {
-        return fileName.replacingOccurrences(of: ".\(fileExtension)", with: "")
-    }
-}
-
-private extension StoryboardFile {
-    var fileExtension: String {
-        return URL.init(fileURLWithPath: pathString).pathExtension
-    }
-    var fileNameWithoutExtension: String {
-        return fileName.replacingOccurrences(of: ".\(fileExtension)", with: "")
-    }
-}
-
 extension Rules {
     public struct UseBaseClassRule: Rule {
 
@@ -42,15 +24,15 @@ extension Rules {
         public func validate(storyboard: StoryboardFile) -> [Violation] {
             guard let scenes = storyboard.document.scenes else { return [] }
             let views = scenes.compactMap { $0.viewController?.viewController.rootView }
-            return views.flatMap { validate(for: $0, file: storyboard, fileNameWithoutExtension: storyboard.fileNameWithoutExtension) }
+            return views.flatMap { validate(for: $0, file: storyboard) }
         }
 
         public func validate(xib: XibFile) -> [Violation] {
             guard let views = xib.document.views else { return [] }
-            return views.flatMap { validate(for: $0.view, file: xib, fileNameWithoutExtension: xib.fileNameWithoutExtension) }
+            return views.flatMap { validate(for: $0.view, file: xib) }
         }
 
-        private func validate<T: InterfaceBuilderFile>(for view: ViewProtocol, file: T, fileNameWithoutExtension: String) -> [Violation] {
+        private func validate<T: InterfaceBuilderFile>(for view: ViewProtocol, file: T) -> [Violation] {
             let violation: [Violation] = {
                 guard let baseClassesForElement = baseClasses[view.elementClass] else { return [] }
                 guard let customClass = view.customClass else {
@@ -64,7 +46,7 @@ extension Rules {
                 }
                 return []
             }()
-            return violation + (view.subviews?.flatMap { validate(for: $0.view, file: file, fileNameWithoutExtension: fileNameWithoutExtension) } ?? [])
+            return violation + (view.subviews?.flatMap { validate(for: $0.view, file: file) } ?? [])
         }
     }
 }

--- a/Sources/IBLinterKit/UseBaseClassConfig.swift
+++ b/Sources/IBLinterKit/UseBaseClassConfig.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct BaseClassConfig: Codable {
+public struct UseBaseClassConfig: Codable {
     public let elementClass: String
     public let baseClasses: [String]
 
@@ -16,7 +16,7 @@ public struct BaseClassConfig: Codable {
         case baseClasses = "base_classes"
     }
 
-    public static let `default` = BaseClassConfig.init()
+    public static let `default` = UseBaseClassConfig.init()
 
     private init() {
         elementClass = ""

--- a/Sources/IBLinterKit/UseBaseClassConfig.swift
+++ b/Sources/IBLinterKit/UseBaseClassConfig.swift
@@ -16,13 +16,6 @@ public struct UseBaseClassConfig: Codable {
         case baseClasses = "base_classes"
     }
 
-    public static let `default` = UseBaseClassConfig.init()
-
-    private init() {
-        elementClass = ""
-        baseClasses = []
-    }
-
     init(elementClass: String, baseClasses: [String]) {
         self.elementClass = elementClass
         self.baseClasses = baseClasses
@@ -30,7 +23,7 @@ public struct UseBaseClassConfig: Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        elementClass = try container.decodeIfPresent(Optional<String>.self, forKey: .elementClass).flatMap { $0 } ?? ""
+        elementClass = try container.decode(String.self, forKey: .elementClass)
         baseClasses = try container.decodeIfPresent(Optional<[String]>.self, forKey: .baseClasses)?.flatMap { $0 } ?? []
     }
 }

--- a/Tests/IBLinterKitTest/Resources/.iblinter.yml
+++ b/Tests/IBLinterKitTest/Resources/.iblinter.yml
@@ -12,7 +12,7 @@ custom_module_rule:
     excluded:
       - UIComponents/Classes/Config/Generated
 use_base_class_rule:
-  - element_name: UILabel
-  - base_classes:
+  - element_class: UILabel
+    base_classes:
     - PrimaryLabel
     - SecondaryLabel

--- a/Tests/IBLinterKitTest/Resources/.iblinter.yml
+++ b/Tests/IBLinterKitTest/Resources/.iblinter.yml
@@ -11,4 +11,8 @@ custom_module_rule:
       - UIComponents/Classes
     excluded:
       - UIComponents/Classes/Config/Generated
-
+use_base_class_rule:
+  - element_name: UILabel
+  - base_classes:
+    - PrimaryLabel
+    - SecondaryLabel

--- a/Tests/IBLinterKitTest/Resources/UseBaseClassTest.xib
+++ b/Tests/IBLinterKitTest/Resources/UseBaseClassTest.xib
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="UILabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ToM-Be-eNG">
+                    <rect key="frame" x="158" y="119" width="58" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="PrimaryLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xlx-5v-ehz" customClass="PrimaryLabel">
+                    <rect key="frame" x="137" y="163" width="101" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="SecondaryLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A8L-Jg-8BD" customClass="SecondaryLabel">
+                    <rect key="frame" x="125" y="216" width="124" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+        </view>
+    </objects>
+</document>

--- a/Tests/IBLinterKitTest/RuleTest.swift
+++ b/Tests/IBLinterKitTest/RuleTest.swift
@@ -85,7 +85,7 @@ class RuleTest: XCTestCase {
     func testUseBaseClass() {
         let url = self.url(forResource: "UseBaseClassTest", withExtension: "xib")
         let defaultEnabledRules = Rules.defaultRules.map({ $0.identifier })
-        let config = Config(disabledRules: defaultEnabledRules, enabledRules: [], excluded: [], included: [], customModuleRule: [], baseClassRule: [BaseClassConfig(elementClass: "UILabel", baseClasses: ["PrimaryLabel", "SecondaryLabel"])], reporter: "xcode")
+        let config = Config(disabledRules: defaultEnabledRules, enabledRules: [], excluded: [], included: [], customModuleRule: [], baseClassRule: [UseBaseClassConfig(elementClass: "UILabel", baseClasses: ["PrimaryLabel", "SecondaryLabel"])], reporter: "xcode")
         let rule = Rules.UseBaseClassRule(context: context(from: config))
         let violations = try! rule.validate(xib: XibFile(url: url))
         XCTAssertEqual(violations.count, 1)

--- a/Tests/IBLinterKitTest/RuleTest.swift
+++ b/Tests/IBLinterKitTest/RuleTest.swift
@@ -31,7 +31,7 @@ class RuleTest: XCTestCase {
 
     func testDefaultEnabledRules() {
         let defaultEnabledRules = Rules.defaultRules.map({ $0.identifier })
-        let config = Config(disabledRules: [], enabledRules: [], excluded: [], included: [], customModuleRule: [], reporter: "xcode")
+        let config = Config(disabledRules: [], enabledRules: [], excluded: [], included: [], customModuleRule: [], baseClassRule: [], reporter: "xcode")
         let rules = Rules.rules(context(from: config))
         XCTAssertEqual(Set(rules.map({ type(of:$0).identifier })), Set(defaultEnabledRules))
         XCTAssertEqual(rules.count, defaultEnabledRules.count)
@@ -39,7 +39,7 @@ class RuleTest: XCTestCase {
 
     func testDisableDefaultEnabledRules() {
         let defaultEnabledRules = Rules.defaultRules.map({ $0.identifier })
-        let config = Config(disabledRules: defaultEnabledRules, enabledRules: [], excluded: [], included: [], customModuleRule: [], reporter: "xcode")
+        let config = Config(disabledRules: defaultEnabledRules, enabledRules: [], excluded: [], included: [], customModuleRule: [], baseClassRule: [], reporter: "xcode")
         let rules = Rules.rules(context(from: config))
         XCTAssertEqual(Set(rules.map({ type(of:$0).identifier })), Set())
         XCTAssertEqual(rules.count, 0)
@@ -47,7 +47,7 @@ class RuleTest: XCTestCase {
 
     func testDuplicatedEnabledRules() {
         let defaultEnabledRules = Rules.defaultRules.map({ $0.identifier })
-        let config = Config(disabledRules: [], enabledRules: defaultEnabledRules, excluded: [], included: [], customModuleRule: [], reporter: "xcode")
+        let config = Config(disabledRules: [], enabledRules: defaultEnabledRules, excluded: [], included: [], customModuleRule: [], baseClassRule: [], reporter: "xcode")
         let rules = Rules.rules(context(from: config))
         XCTAssertEqual(Set(rules.map({ type(of:$0).identifier })), Set(defaultEnabledRules))
         XCTAssertEqual(rules.count, defaultEnabledRules.count)
@@ -63,7 +63,7 @@ class RuleTest: XCTestCase {
 
     func testCustomModule() {
         let defaultEnabledRules = Rules.defaultRules.map({ $0.identifier })
-        let config = Config(disabledRules: defaultEnabledRules, enabledRules: ["custom_module"], excluded: [], included: [], customModuleRule: [CustomModuleConfig(module: "TestCustomModule", included: ["Tests/IBLinterKitTest/Resources/TestCustomModule"], excluded: ["Tests/IBLinterKitTest/Resources/TestCustomModule/CustomModuleExcluded"])], reporter: "xcode")
+        let config = Config(disabledRules: defaultEnabledRules, enabledRules: ["custom_module"], excluded: [], included: [], customModuleRule: [CustomModuleConfig(module: "TestCustomModule", included: ["Tests/IBLinterKitTest/Resources/TestCustomModule"], excluded: ["Tests/IBLinterKitTest/Resources/TestCustomModule/CustomModuleExcluded"])], baseClassRule: [], reporter: "xcode")
         let rules = Rules.rules(context(from: config))
         XCTAssertEqual(Set(rules.map({ type(of:$0).identifier })), Set(["custom_module"]))
         let rule = rules[0]
@@ -80,6 +80,15 @@ class RuleTest: XCTestCase {
         let rule = Rules.AmbiguousViewRule(context: context(from: .default))
         let violations = try! rule.validate(storyboard: StoryboardFile(url: url))
         XCTAssertEqual(violations.count, 2)
+    }
+
+    func testUseBaseClass() {
+        let url = self.url(forResource: "UseBaseClassTest", withExtension: "xib")
+        let defaultEnabledRules = Rules.defaultRules.map({ $0.identifier })
+        let config = Config(disabledRules: defaultEnabledRules, enabledRules: [], excluded: [], included: [], customModuleRule: [], baseClassRule: [BaseClassConfig(elementClass: "UILabel", baseClasses: ["PrimaryLabel", "SecondaryLabel"])], reporter: "xcode")
+        let rule = Rules.UseBaseClassRule(context: context(from: config))
+        let violations = try! rule.validate(xib: XibFile(url: url))
+        XCTAssertEqual(violations.count, 1)
     }
 }
 

--- a/Tests/IBLinterTest/Config+LintablePathsTests.swift
+++ b/Tests/IBLinterTest/Config+LintablePathsTests.swift
@@ -9,7 +9,7 @@ class ConfigLintablePathsTests: XCTestCase {
         let config = Config(
             disabledRules: [], enabledRules: [],
             excluded: ["Level1_1"], included: [],
-            customModuleRule: [], reporter: ""
+            customModuleRule: [], baseClassRule: [], reporter: ""
         )
         let projectPath = bundleURL.appendingPathComponent("ProjectMock")
         let lintablePaths = config.lintablePaths(workDirectory: projectPath, fileExtension: "xib")
@@ -24,7 +24,7 @@ class ConfigLintablePathsTests: XCTestCase {
         let config = Config(
             disabledRules: [], enabledRules: [],
             excluded: [], included: ["Level1_2"],
-            customModuleRule: [], reporter: ""
+            customModuleRule: [], baseClassRule: [], reporter: ""
         )
         let projectPath = bundleURL.appendingPathComponent("ProjectMock")
         let lintablePaths = config.lintablePaths(workDirectory: projectPath, fileExtension: "xib")
@@ -39,7 +39,7 @@ class ConfigLintablePathsTests: XCTestCase {
         let config = Config(
             disabledRules: [], enabledRules: [],
             excluded: ["Level1_1"], included: ["Level1_1/Level2_1"],
-            customModuleRule: [], reporter: ""
+            customModuleRule: [], baseClassRule: [], reporter: ""
         )
         let projectPath = bundleURL.appendingPathComponent("ProjectMock")
         let lintablePaths = config.lintablePaths(workDirectory: projectPath, fileExtension: "xib")


### PR DESCRIPTION
This PR is a proposal of a new rule, `UseBaseClass`.

# What is `UseBaseClass` rule?

`UseBaseClass` rule is a rule to check whether an UI element uses custom class which is set as base class in config.

For example,  if we have some base classes  of `UILabel` like `PrimaryLabel` and `SecondaryLabel` that should be applied to all labels through the project, this rule checks whether labels in storyboards and xibs are set to base classes.


# Why is this rule required?

As I describe above, many apps commonly have their own base UI components. But we often forget to set the custom class to the base classes in storyboard or xib. And new members often overlook the base components.

This rule can prevent the problem and this is the reason why I developed this rule.

# How does it work?

Set `element_class` and `base_classes` in config like
```
use_base_class_rule:
  - element_class: UILabel
    base_classes:
      - PrimaryLabel
      - SecondaryLabel 
```

This enables to check `UILabel` uses `PrimaryLabel` or `SecondaryLabel`. If `UILabel` does not use the base classes, Xcode shows warnings like below.

<img width="1397" alt="Screen Shot 2019-03-11 at 18 53 35" src="https://user-images.githubusercontent.com/1473923/54115019-0b955b00-442f-11e9-93a9-7f4564db9a82.png">

