### PR TITLE
Adds rules to keep "View as" device

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tadija/AEXML.git",
         "state": {
           "branch": null,
-          "revision": "6eea665515d079c338690147082a8084a36484b0",
-          "version": "4.3.0"
+          "revision": "54bb8ea6fb693dd3f92a89e5fcc19e199fdeedd0",
+          "version": "4.3.3"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/JohnSundell/Files.git",
         "state": {
           "branch": null,
-          "revision": "06f95bd1bf4f8d5f50bc6bb30b808c253acd4c88",
-          "version": "2.2.1"
+          "revision": "a84615f4558151fab52ac38df697ce2442991f93",
+          "version": "2.3.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "cd6dfb86f496fcd96ce0bc6da962cd936bf41903",
-          "version": "7.3.1"
+          "revision": "e9d769113660769a4d9dd3afb855562c0b7ae7b0",
+          "version": "7.3.4"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "5fbf13871d185526993130c3a1fad0b70bfe37ce",
-          "version": "1.3.2"
+          "revision": "f2b5a06440ea87eba1a167cab37bf6496646c52e",
+          "version": "1.3.4"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/antitypical/Result.git",
         "state": {
           "branch": null,
-          "revision": "8fc088dcf72802801efeecba76ea8fb041fb773d",
-          "version": "4.0.0"
+          "revision": "2ca499ba456795616fbc471561ff1d963e6ae160",
+          "version": "4.1.0"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
         "state": {
           "branch": null,
-          "revision": "f1c253a34a40df4bfd268b09fdb101b059f6d52d",
-          "version": "2.1.0"
+          "revision": "d3d54ce662dfee7fef619330b71d251b8d4869f9",
+          "version": "2.2.0"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
         "state": {
           "branch": null,
-          "revision": "4be914be6fa49cd30b1e7ef5d32d06c037d8f469",
-          "version": "0.21.2"
+          "revision": "176f04295a09324673245d8ec0afcce21ace8722",
+          "version": "0.22.0"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
         "state": {
           "branch": null,
-          "revision": "0ce63a93a455adb3cd5e4c55f78f1232a590a5a5",
-          "version": "4.7.2"
+          "revision": "0d6bb315528888edde0dafe93564f074669c44e9",
+          "version": "4.8.0"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/JohnSundell/Unbox.git",
         "state": {
           "branch": null,
-          "revision": "e084f13aea85495b07d015e893845e097a5eaeb4",
-          "version": "3.0.0"
+          "revision": "9575afeb61597fdea9070ca07effede5fb37c2c8",
+          "version": "3.1.0"
         }
       },
       {

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ You can configure `view_as_device` rule by `ViewAsDeviceConfig`. If there are no
 |:------------------|:---------------------------------- |
 | `device_id`       | Device id for device.              |
 
-**appx.** Table of mapping device name to `device_id` (on `XCode 10.2`) 
+**appx.** Table of mapping device name to `device_id` (on `Xcode 10.2`) 
 
 | device name       | device id            |
 |:------------------|:-------------------- |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Alternatively, if you've installed IBLinter via CocoaPods the script should look
 | `image_resources`              | Check if image resources are valid.                                            |
 | `custom_module`                | Check if custom class match custom module by `custom_module_rule` config.      |
 | `use_base_class`               | Check if custom class is in base classes by `use_base_class_rule` config.      |
+| `view_as_device`               | Check `View as:` set as a device specified by `view_as_device_rule` config.    |
 
 
 Pull requests are encouraged.
@@ -95,6 +96,7 @@ You can configure IBLinter by adding a `.iblinter.yml` file from project root di
 | `included`           | Path to include for lint.   |
 | `custom_module_rule` | Custom module rule configs. |
 | `use_base_class_rule`| Use base class rule configs.|
+| `view_as_device_rule`| View as device rule configs.|
 
 ### CustomModuleConfig
 
@@ -116,6 +118,26 @@ You can configure `use_base_class` rule by `UseBaseClassConfig` list.
 | `base_classes`    | Base classes of the element class. |
 
 **Note:** UseBaseClassRule does not work for classes that inherit base class. You need to add all classes to `base_classes` to check.
+
+### ViewAsDeviceConfig
+
+You can configure `view_as_device` rule by `ViewAsDeviceConfig`. If there are no config, `device_id` is set as `retina4_7`.  
+
+| key               | description                        |
+|:------------------|:---------------------------------- |
+| `device_id`       | Device id for device.              |
+
+**appx.** Table of mapping device name to `device_id` (on `XCode 10.2`) 
+
+| device name       | device id            |
+|:------------------|:-------------------- |
+| `iPhone 4s`       | `retina3_5`          |
+| `iPhone SE`       | `retina4_0`          |
+| `iPhone 8`        | `retina4_7`          |
+| `iPhone 8 Plus`   | `retina5_5`          |
+| `iPhone XS`       | `retina5_9`          |
+| `iPhone XR`       | `retina6_1`          |
+| `iPhone XS Max`   | `retina6_5`          |
 
 
 ```yaml
@@ -139,4 +161,6 @@ use_base_class_rule:
     base_classes:
       - PrimaryLabel
       - SecondaryLabel
+view_as_device_rule:
+  device_id: retina4_0
 ```

--- a/Sources/IBLinterKit/Config.swift
+++ b/Sources/IBLinterKit/Config.swift
@@ -15,6 +15,7 @@ public struct Config: Codable {
     public let included: [String]
     public let customModuleRule: [CustomModuleConfig]
     public let useBaseClassRule: [UseBaseClassConfig]
+    public let viewAsDeviceRule: ViewAsDeviceConfig?
     public let reporter: String
     public let disableWhileBuildingForIB: Bool
 
@@ -25,6 +26,7 @@ public struct Config: Codable {
         case included = "included"
         case customModuleRule = "custom_module_rule"
         case useBaseClassRule = "use_base_class_rule"
+        case viewAsDeviceRule = "view_as_device_rule"
         case reporter = "reporter"
         case disableWhileBuildingForIB = "disable_while_building_for_ib"
     }
@@ -39,17 +41,22 @@ public struct Config: Codable {
         included = []
         customModuleRule = []
         useBaseClassRule = []
+        viewAsDeviceRule = nil
         reporter = "xcode"
         disableWhileBuildingForIB = true
     }
 
-    init(disabledRules: [String], enabledRules: [String], excluded: [String], included: [String], customModuleRule: [CustomModuleConfig], baseClassRule: [UseBaseClassConfig], reporter: String, disableWhileBuildingForIB: Bool = true) {
+    init(disabledRules: [String] = [], enabledRules: [String] = [],
+        excluded: [String] = [], included: [String] = [],
+        customModuleRule: [CustomModuleConfig] = [], baseClassRule: [UseBaseClassConfig] = [], viewAsDeviceRule: ViewAsDeviceConfig? = nil,
+        reporter: String = "", disableWhileBuildingForIB: Bool = true) {
         self.disabledRules = disabledRules
         self.enabledRules = enabledRules
         self.excluded = excluded
         self.included = included
         self.customModuleRule = customModuleRule
         self.useBaseClassRule = baseClassRule
+        self.viewAsDeviceRule = viewAsDeviceRule
         self.reporter = reporter
         self.disableWhileBuildingForIB = disableWhileBuildingForIB
     }
@@ -62,6 +69,7 @@ public struct Config: Codable {
         included = try container.decodeIfPresent(Optional<[String]>.self, forKey: .included).flatMap { $0 } ?? []
         customModuleRule = try container.decodeIfPresent(Optional<[CustomModuleConfig]>.self, forKey: .customModuleRule).flatMap { $0 } ?? []
         useBaseClassRule = try container.decodeIfPresent(Optional<[UseBaseClassConfig]>.self, forKey: .useBaseClassRule)?.flatMap { $0 } ?? []
+        viewAsDeviceRule = try container.decodeIfPresent(Optional<ViewAsDeviceConfig>.self, forKey: .viewAsDeviceRule) ?? nil
         reporter = try container.decodeIfPresent(String.self, forKey: .reporter) ?? "xcode"
         disableWhileBuildingForIB = try container.decodeIfPresent(Bool.self, forKey: .disableWhileBuildingForIB) ?? true
     }

--- a/Sources/IBLinterKit/Config.swift
+++ b/Sources/IBLinterKit/Config.swift
@@ -49,7 +49,7 @@ public struct Config: Codable {
     init(disabledRules: [String] = [], enabledRules: [String] = [],
         excluded: [String] = [], included: [String] = [],
         customModuleRule: [CustomModuleConfig] = [], baseClassRule: [UseBaseClassConfig] = [], viewAsDeviceRule: ViewAsDeviceConfig? = nil,
-        reporter: String = "", disableWhileBuildingForIB: Bool = true) {
+        reporter: String = "xcode", disableWhileBuildingForIB: Bool = true) {
         self.disabledRules = disabledRules
         self.enabledRules = enabledRules
         self.excluded = excluded

--- a/Sources/IBLinterKit/Rules/Rule.swift
+++ b/Sources/IBLinterKit/Rules/Rule.swift
@@ -28,6 +28,7 @@ public struct Rules {
             CustomModuleRule.self,
             UseBaseClassRule.self,
             AmbiguousViewRule.self,
+            ViewAsDeviceRule.self,
         ]
     }()
 

--- a/Sources/IBLinterKit/Rules/ViewAsDeviceRule.swift
+++ b/Sources/IBLinterKit/Rules/ViewAsDeviceRule.swift
@@ -1,0 +1,49 @@
+//
+//  ViewAsDeviceRule.swift
+//  IBLinterKit
+//
+//  Created by Shinichi Hosokawa on 2019/03/25.
+//
+
+import IBDecodable
+
+fileprivate func deviceName(from deviceId: String) -> String {
+    switch deviceId {
+    case "retina3_5": return "iPhone 4s"
+    case "retina4_0": return "iPhone SE"
+    case "retina4_7": return "iPhone 8"
+    case "retina5_5": return "iPhone 8 Plus"
+    case "retina5_9": return "iPhone XS"
+    case "retina6_1": return "iPhone XR"
+    case "retina6_5": return "iPhone XS Max"
+    default: return "Unknown device"
+    }
+}
+
+
+extension Rules {
+    fileprivate static func violation<T: InterfaceBuilderFile>(deviceIdToFit: String, file: T) -> [Violation] {
+        guard let document = file.document as? InterfaceBuilderDocument,
+            let deviceId = document.device?.id else {
+            let message = "\"View as:\" should be \(deviceName(from: deviceIdToFit)) (\(deviceIdToFit)) explicitly"
+            return [Violation(pathString: file.pathString, message: message, level: .warning)]
+        }
+        let message = "\"View as:\" should be \(deviceName(from: deviceIdToFit)) (\(deviceIdToFit)). Currently it is \(deviceName(from: deviceId)) (\(deviceId))."
+        return deviceId == deviceIdToFit ? [] : [Violation(pathString: file.pathString, message: message, level: .warning)]
+    }
+
+    public struct ViewAsDeviceRule: Rule {
+        public static var identifier: String = "view_as_device"
+
+        public let deviceIdToFit: String
+        public init(context: Context) {
+            deviceIdToFit = context.config.viewAsDeviceRule?.deviceId ?? "retina4_7"
+        }
+        public func validate(storyboard: StoryboardFile) -> [Violation] {
+            return Rules.violation(deviceIdToFit: deviceIdToFit, file: storyboard)
+        }
+        public func validate(xib: XibFile) -> [Violation] {
+            return Rules.violation(deviceIdToFit: deviceIdToFit, file: xib)
+        }
+    }
+}

--- a/Sources/IBLinterKit/ViewAsDeviceConfig.swift
+++ b/Sources/IBLinterKit/ViewAsDeviceConfig.swift
@@ -1,0 +1,24 @@
+//
+//  ViewAsDeviceConfig.swift
+//
+//  Created by shosokawa on 2019/03/26.
+//
+
+import Foundation
+
+public struct ViewAsDeviceConfig: Codable {
+    public let deviceId: String
+
+    enum CodingKeys: String, CodingKey {
+        case deviceId = "device_id"
+    }
+
+    init(deviceId: String) {
+        self.deviceId = deviceId
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        deviceId = try container.decode(String.self, forKey: .deviceId)
+    }
+}

--- a/Tests/IBLinterKitTest/ConfigTest.swift
+++ b/Tests/IBLinterKitTest/ConfigTest.swift
@@ -21,4 +21,12 @@ class ConfigTest: XCTestCase {
         XCTAssertEqual(config.enabledRules, [])
         XCTAssertEqual(config.excluded, ["Carthage"])
     }
+
+    func testViewAsDeviceConfigFile() throws {
+        let url = self.url(forResource: ".iblinter_view_as_device", withExtension: "yml")
+        let workingDirectory = url.deletingLastPathComponent()
+        let config = try Config.load(from: workingDirectory, fileName: url.lastPathComponent)
+        XCTAssertNotNil(config.viewAsDeviceRule)
+        XCTAssertEqual(config.viewAsDeviceRule?.deviceId, "retina3_5")
+    }
 }

--- a/Tests/IBLinterKitTest/Resources/.iblinter_view_as_device.yml
+++ b/Tests/IBLinterKitTest/Resources/.iblinter_view_as_device.yml
@@ -1,0 +1,7 @@
+disabled_rules:
+  - custom_class_name
+enabled_rules: 
+excluded:
+  - Carthage
+view_as_device_rule:
+  device_id: retina3_5

--- a/Tests/IBLinterKitTest/Resources/ViewAsRetina4_0Test.storyboard
+++ b/Tests/IBLinterKitTest/Resources/ViewAsRetina4_0Test.storyboard
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_0" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+    </dependencies>
+    <scenes/>
+</document>

--- a/Tests/IBLinterKitTest/Resources/ViewAsRetina4_7Test.storyboard
+++ b/Tests/IBLinterKitTest/Resources/ViewAsRetina4_7Test.storyboard
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+    </dependencies>
+    <scenes/>
+</document>

--- a/Tests/IBLinterKitTest/Resources/ViewAsRetina6_5Test.storyboard
+++ b/Tests/IBLinterKitTest/Resources/ViewAsRetina6_5Test.storyboard
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_5" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+    </dependencies>
+    <scenes/>
+</document>

--- a/Tests/IBLinterKitTest/RuleTest.swift
+++ b/Tests/IBLinterKitTest/RuleTest.swift
@@ -90,6 +90,29 @@ class RuleTest: XCTestCase {
         let violations = try! rule.validate(xib: XibFile(url: url))
         XCTAssertEqual(violations.count, 1)
     }
+
+    func testViewAsDeviceWithNoConfig() {
+        let ngUrl = self.url(forResource: "ViewAsRetina6_5Test", withExtension: "storyboard")
+        let ngRule = Rules.ViewAsDeviceRule(context: context(from: .default))
+        let ngViolations = try! ngRule.validate(xib: XibFile(url: ngUrl))
+        XCTAssertEqual(ngViolations.count, 1)
+        let okUrl = self.url(forResource: "ViewAsRetina4_7Test", withExtension: "storyboard")
+        let okRule = Rules.ViewAsDeviceRule(context: context(from: .default))
+        let okViolations = try! okRule.validate(xib: XibFile(url: okUrl))
+        XCTAssertEqual(okViolations.count, 0)
+    }
+
+    func testViewAsDeviceWithConfig() {
+        let config = Config(viewAsDeviceRule: ViewAsDeviceConfig(deviceId: "retina4_0"))
+        let ngUrl = self.url(forResource: "ViewAsRetina6_5Test", withExtension: "storyboard")
+        let ngRule = Rules.ViewAsDeviceRule(context: context(from: config))
+        let ngViolations = try! ngRule.validate(xib: XibFile(url: ngUrl))
+        XCTAssertEqual(ngViolations.count, 1)
+        let okUrl = self.url(forResource: "ViewAsRetina4_0Test", withExtension: "storyboard")
+        let okRule = Rules.ViewAsDeviceRule(context: context(from: config))
+        let okViolations = try! okRule.validate(xib: XibFile(url: okUrl))
+        XCTAssertEqual(okViolations.count, 0)
+    }
 }
 
 // MARK: resource utils


### PR DESCRIPTION
This PR is to add rules to keep "View as" device for files as specific one. 
"View as" is useful to confirm that constraints are working correctly on any types of devices. But sometimes we got unnecessary difference for `.storyboard` unexpectedly when it is left as changed from previous commit. This unexpected difference makes management of `.storyboard` files more complex. So I consider that it is useful to keep "View as" device at least on commits.