### PR TITLE
Resolve custom module path

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,10 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 
 import PackageDescription
 
 let package = Package(
     name: "IBLinter",
+    platforms: [.macOS(.v10_11)],
     products: [
         .executable(
             name: "iblinter", targets: ["IBLinter"]

--- a/Sources/IBLinterKit/Rules/CustomModuleRule.swift
+++ b/Sources/IBLinterKit/Rules/CustomModuleRule.swift
@@ -51,12 +51,8 @@ extension Rules {
             }
 
             func resolvePath(_ includeURLString: String) -> URL {
-                if #available(OSX 10.11, *) {
-                    let url = URL(fileURLWithPath: includeURLString, relativeTo: context.workDirectory)
-                    return url.standardizedFileURL
-                } else {
-                    fatalError("Unsupported OS version")
-                }
+                let url = URL(fileURLWithPath: includeURLString, relativeTo: context.workDirectory)
+                return url.standardizedFileURL
             }
             func expandGlob(_ baseDirectory: URL) -> Set<URL> {
                 return glob(pattern: baseDirectory.appendingPathComponent("**").appendingPathComponent("*.swift").path)

--- a/Sources/IBLinterKit/Rules/CustomModuleRule.swift
+++ b/Sources/IBLinterKit/Rules/CustomModuleRule.swift
@@ -62,8 +62,8 @@ extension Rules {
                 return glob(pattern: baseDirectory.appendingPathComponent("**").appendingPathComponent("*.swift").path)
             }
             moduleClasses = context.config.customModuleRule.reduce(into: [:]) { moduleClasses, customModuleConfig in
-                let paths = customModuleConfig.included.map(resolvePath).flatMap { expandGlob($0) }
-                let excluded = customModuleConfig.excluded.map(resolvePath).flatMap { expandGlob($0) }
+                let paths = customModuleConfig.included.map(resolvePath).flatMap(expandGlob)
+                let excluded = customModuleConfig.excluded.map(resolvePath).flatMap(expandGlob)
                 let lintablePaths = paths.filter { !excluded.map { $0.absoluteString }.contains($0.absoluteString) }
                 let classes: [String] = lintablePaths.flatMap(classes(from: ))
                 moduleClasses[customModuleConfig.module] = classes

--- a/Sources/IBLinterKit/Rules/CustomModuleRule.swift
+++ b/Sources/IBLinterKit/Rules/CustomModuleRule.swift
@@ -50,9 +50,20 @@ extension Rules {
                 }
             }
 
+            func resolvePath(_ includeURLString: String) -> URL {
+                if #available(OSX 10.11, *) {
+                    let url = URL(fileURLWithPath: includeURLString, relativeTo: context.workDirectory)
+                    return url.standardizedFileURL
+                } else {
+                    fatalError("Unsupported OS version")
+                }
+            }
+            func expandGlob(_ baseDirectory: URL) -> Set<URL> {
+                return glob(pattern: baseDirectory.appendingPathComponent("**").appendingPathComponent("*.swift").path)
+            }
             moduleClasses = context.config.customModuleRule.reduce(into: [:]) { moduleClasses, customModuleConfig in
-                let paths = customModuleConfig.included.flatMap { glob(pattern: "\($0)/**/*.swift") }
-                let excluded = customModuleConfig.excluded.flatMap { glob(pattern: "\($0)/**/*.swift") }
+                let paths = customModuleConfig.included.map(resolvePath).flatMap { expandGlob($0) }
+                let excluded = customModuleConfig.excluded.map(resolvePath).flatMap { expandGlob($0) }
                 let lintablePaths = paths.filter { !excluded.map { $0.absoluteString }.contains($0.absoluteString) }
                 let classes: [String] = lintablePaths.flatMap(classes(from: ))
                 moduleClasses[customModuleConfig.module] = classes


### PR DESCRIPTION
Currently, `custom_module_rule` didn't accept relative paths.

```yaml
custom_module_rule:
  - module: UIComponents
    included:
      - UIComponents # not working
      - /Users/giginet/path/to/my/project/UIComponents # accepted
```

This PR make it enable resolving relative URL.