### PR TITLE
Add option --config to specify configuration file path 

### DIFF
--- a/Sources/IBLinterFrontend/Commands/ValidateCommand.swift
+++ b/Sources/IBLinterFrontend/Commands/ValidateCommand.swift
@@ -83,12 +83,12 @@ extension ProcessInfo {
 extension Config {
     init?(options: ValidateOptions) {
         if let configurationFile = options.configurationFile {
-            let workDirectory = URL(fileURLWithPath: configurationFile)
-            try? self.init(workDirectory)
+            let configurationURL = URL(fileURLWithPath: configurationFile)
+            try? self.init(url: configurationURL)
         } else {
             let workDirectoryString = options.path ?? FileManager.default.currentDirectoryPath
             let workDirectory = URL(fileURLWithPath: workDirectoryString)
-            try? self.init(from: workDirectory)
+            try? self.init(directoryURL: workDirectory)
         }
     }
 }

--- a/Sources/IBLinterFrontend/Commands/ValidateCommand.swift
+++ b/Sources/IBLinterFrontend/Commands/ValidateCommand.swift
@@ -25,7 +25,7 @@ struct ValidateCommand: CommandProtocol {
         guard FileManager.default.isDirectory(workDirectory.path) else {
             fatalError("\(workDirectoryString) is not directory.")
         }
-        
+
         let config = Config(options: options) ?? Config.default
         if config.disableWhileBuildingForIB &&
             ProcessInfo.processInfo.compiledForInterfaceBuilder {
@@ -81,7 +81,7 @@ extension ProcessInfo {
 }
 
 extension Config {
-    init?(options: ValidateOptions)  {
+    init?(options: ValidateOptions) {
         if let configurationFile = options.configurationFile {
             let workDirectory = URL(fileURLWithPath: configurationFile)
             try? self.init(workDirectory)

--- a/Sources/IBLinterKit/Config/Config.swift
+++ b/Sources/IBLinterKit/Config/Config.swift
@@ -76,12 +76,12 @@ public struct Config: Codable {
         disableWhileBuildingForIB = try container.decodeIfPresent(Bool.self, forKey: .disableWhileBuildingForIB) ?? true
     }
 
-    public static func load(_ url: URL) throws -> Config {
-        return try YAMLDecoder.init().decode(from: String.init(contentsOf: url))
+    public init(_ url: URL) throws {
+        self = try YAMLDecoder().decode(from: String.init(contentsOf: url))
     }
 
-    public static func load(from configPath: URL, fileName: String = fileName) throws -> Config {
+    public init(from configPath: URL, fileName: String = fileName) throws {
         let url = configPath.appendingPathComponent(fileName)
-        return try load(url)
+        try self.init(url)
     }
 }

--- a/Sources/IBLinterKit/Config/Config.swift
+++ b/Sources/IBLinterKit/Config/Config.swift
@@ -76,12 +76,12 @@ public struct Config: Codable {
         disableWhileBuildingForIB = try container.decodeIfPresent(Bool.self, forKey: .disableWhileBuildingForIB) ?? true
     }
 
-    public init(_ url: URL) throws {
+    public init(url: URL) throws {
         self = try YAMLDecoder().decode(from: String.init(contentsOf: url))
     }
 
-    public init(from configPath: URL, fileName: String = fileName) throws {
-        let url = configPath.appendingPathComponent(fileName)
-        try self.init(url)
+    public init(directoryURL: URL, fileName: String = fileName) throws {
+        let url = directoryURL.appendingPathComponent(fileName)
+        try self.init(url: url)
     }
 }

--- a/Tests/IBLinterKitTest/Utils/ConfigTest.swift
+++ b/Tests/IBLinterKitTest/Utils/ConfigTest.swift
@@ -8,7 +8,7 @@ class ConfigTest: XCTestCase {
     func testConfigFile() throws {
         let url = fixture.path("Resources/Config/.iblinter.yml")
         let workingDirectory = url.deletingLastPathComponent()
-        let config = try Config(from: workingDirectory)
+        let config = try Config(directoryURL: workingDirectory)
         XCTAssertEqual(config.disabledRules, ["custom_class_name"])
         XCTAssertEqual(config.enabledRules, ["relative_to_margin"])
         XCTAssertEqual(config.excluded, ["Carthage"])
@@ -18,7 +18,7 @@ class ConfigTest: XCTestCase {
     func testNullableConfigFile() throws {
         let url = fixture.path("Resources/Config/.iblinter_nullable.yml")
         let workingDirectory = url.deletingLastPathComponent()
-        let config = try Config(from: workingDirectory, fileName: url.lastPathComponent)
+        let config = try Config(directoryURL: workingDirectory, fileName: url.lastPathComponent)
         XCTAssertEqual(config.disabledRules, ["custom_class_name"])
         XCTAssertEqual(config.enabledRules, [])
         XCTAssertEqual(config.excluded, ["Carthage"])
@@ -27,7 +27,7 @@ class ConfigTest: XCTestCase {
     func testViewAsDeviceConfigFile() throws {
         let url = fixture.path("Resources/Config/.iblinter_view_as_device.yml")
         let workingDirectory = url.deletingLastPathComponent()
-        let config = try Config(from: workingDirectory, fileName: url.lastPathComponent)
+        let config = try Config(directoryURL: workingDirectory, fileName: url.lastPathComponent)
         XCTAssertNotNil(config.viewAsDeviceRule)
         XCTAssertEqual(config.viewAsDeviceRule?.deviceId, "retina3_5")
     }

--- a/Tests/IBLinterKitTest/Utils/ConfigTest.swift
+++ b/Tests/IBLinterKitTest/Utils/ConfigTest.swift
@@ -8,7 +8,7 @@ class ConfigTest: XCTestCase {
     func testConfigFile() throws {
         let url = fixture.path("Resources/Config/.iblinter.yml")
         let workingDirectory = url.deletingLastPathComponent()
-        let config = try Config.load(from: workingDirectory)
+        let config = try Config(from: workingDirectory)
         XCTAssertEqual(config.disabledRules, ["custom_class_name"])
         XCTAssertEqual(config.enabledRules, ["relative_to_margin"])
         XCTAssertEqual(config.excluded, ["Carthage"])
@@ -18,7 +18,7 @@ class ConfigTest: XCTestCase {
     func testNullableConfigFile() throws {
         let url = fixture.path("Resources/Config/.iblinter_nullable.yml")
         let workingDirectory = url.deletingLastPathComponent()
-        let config = try Config.load(from: workingDirectory, fileName: url.lastPathComponent)
+        let config = try Config(from: workingDirectory, fileName: url.lastPathComponent)
         XCTAssertEqual(config.disabledRules, ["custom_class_name"])
         XCTAssertEqual(config.enabledRules, [])
         XCTAssertEqual(config.excluded, ["Carthage"])
@@ -27,7 +27,7 @@ class ConfigTest: XCTestCase {
     func testViewAsDeviceConfigFile() throws {
         let url = fixture.path("Resources/Config/.iblinter_view_as_device.yml")
         let workingDirectory = url.deletingLastPathComponent()
-        let config = try Config.load(from: workingDirectory, fileName: url.lastPathComponent)
+        let config = try Config(from: workingDirectory, fileName: url.lastPathComponent)
         XCTAssertNotNil(config.viewAsDeviceRule)
         XCTAssertEqual(config.viewAsDeviceRule?.deviceId, "retina3_5")
     }

--- a/Tests/IBLinterKitTest/ValidatorTest.swift
+++ b/Tests/IBLinterKitTest/ValidatorTest.swift
@@ -41,7 +41,7 @@ final class VaridatorTest: XCTestCase {
     func testValidateXib() {
         let workingDir = Fixture().path("Resources/Validator")
         let validator = Validator(externalRules: [CheckXibRule.self])
-        let config = try! Config(workingDir.appendingPathComponent(".iblinter.yml"))
+        let config = try! Config(url: workingDir.appendingPathComponent(".iblinter.yml"))
         let violations = validator.validate(workDirectory: workingDir, config: config)
         XCTAssertEqual(violations.count, 1)
     }
@@ -49,7 +49,7 @@ final class VaridatorTest: XCTestCase {
     func testValidateStoryboard() {
         let workingDir = Fixture().path("Resources/Validator")
         let validator = Validator(externalRules: [CheckStoryboardRule.self])
-        let config = try! Config(workingDir.appendingPathComponent(".iblinter.yml"))
+        let config = try! Config(url: workingDir.appendingPathComponent(".iblinter.yml"))
         let violations = validator.validate(workDirectory: workingDir, config: config)
         XCTAssertEqual(violations.count, 1)
     }

--- a/Tests/IBLinterKitTest/ValidatorTest.swift
+++ b/Tests/IBLinterKitTest/ValidatorTest.swift
@@ -41,7 +41,7 @@ final class VaridatorTest: XCTestCase {
     func testValidateXib() {
         let workingDir = Fixture().path("Resources/Validator")
         let validator = Validator(externalRules: [CheckXibRule.self])
-        let config = try! Config.load(workingDir.appendingPathComponent(".iblinter.yml"))
+        let config = try! Config(workingDir.appendingPathComponent(".iblinter.yml"))
         let violations = validator.validate(workDirectory: workingDir, config: config)
         XCTAssertEqual(violations.count, 1)
     }
@@ -49,7 +49,7 @@ final class VaridatorTest: XCTestCase {
     func testValidateStoryboard() {
         let workingDir = Fixture().path("Resources/Validator")
         let validator = Validator(externalRules: [CheckStoryboardRule.self])
-        let config = try! Config.load(workingDir.appendingPathComponent(".iblinter.yml"))
+        let config = try! Config(workingDir.appendingPathComponent(".iblinter.yml"))
         let violations = validator.validate(workDirectory: workingDir, config: config)
         XCTAssertEqual(violations.count, 1)
     }


### PR DESCRIPTION
Related to  #105

We load configuration from specified file
but the path In rules are related to working directory (or option path)