### PR TITLE
Specify pod platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: objective-c
 osx_image: xcode10.2
 before_script:
+  - pod lib lint
   - swiftlint --strict
 script:
   - swift test

--- a/IBLinter.podspec
+++ b/IBLinter.podspec
@@ -1,5 +1,6 @@
 Pod::Spec.new do |s|
   s.name           = 'IBLinter'
+  s.platform       = :osx
   s.version        = `make current_version`
   s.summary        = 'A linter tool for Interface Builder.'
   s.homepage       = 'https://github.com/IBDecodable/IBLinter'

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ bump_version:
 
 publish:
 		brew update && brew bump-formula-pr --tag=$(shell git describe --tags) --revision=$(shell git rev-parse HEAD) iblinter
-		COCOAPODS_VALIDATOR_SKIP_XCODEBUILD=1 pod trunk push IBLinter.podspec
+		pod trunk push IBLinter.podspec
 
 %:
 	@:


### PR DESCRIPTION
## Problem

CocoaPods attempt to build for all platforms. (such as watchOS!)
It hits the CocoaPods issue.

```
$ pod lib lint

 -> IBLinter (0.4.17)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | xcodebuild:  note: Planning build
    - NOTE  | xcodebuild:  note: Constructing build description
    - NOTE  | xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file and one is not being generated automatically. (in target 'App' from project 'App')
    - ERROR | [watchOS] xcodebuild: Returned an unsuccessful exit code. You can use `--verbose` for more information.
    - NOTE  | [watchOS] xcodebuild:  xcodebuild: error: Unable to find a destination matching the provided destination specifier:

[!] IBLinter did not pass validation, due to 1 error.
You can use the `--no-clean` option to inspect any issue.

```

## Description

- Specify platform for `:osx`
- Linting podspec on Travis CI