### PR TITLE
image_resources: do not detect violations for system images Fix #129

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/IBDecodable/IBDecodable.git",
         "state": {
           "branch": null,
-          "revision": "d290038df73db68678a1eca1d8cbd3237750113d",
-          "version": "0.0.4"
+          "revision": "eef5f041aba7b2a90a366d281184155b0b9d4e2f",
+          "version": "0.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBDecodable/IBDecodable.git", from: "0.0.3"),
+        .package(url: "https://github.com/IBDecodable/IBDecodable.git", from: "0.1.0"),
         .package(url: "https://github.com/Carthage/Commandant.git", .upToNextMinor(from: "0.16.0")),
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.22.0"),
         .package(url: "https://github.com/xcodeswift/xcproj.git", from: "6.6.0"),

--- a/Tests/IBLinterKitTest/Resources/Rules/ImageResourcesRule/StoryboardAsset.storyboard
+++ b/Tests/IBLinterKitTest/Resources/Rules/ImageResourcesRule/StoryboardAsset.storyboard
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -49,6 +47,20 @@
                                 <rect key="frame" x="130" y="37" width="115" height="81"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </imageView>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="grid" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="ExE-Si-hwZ">
+                                <rect key="frame" x="44" y="232" width="115" height="81"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </imageView>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KOB-9f-vNx">
+                                <rect key="frame" x="180" y="235" width="18" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button" image="Apple"/>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7li-IW-9gq">
+                                <rect key="frame" x="206" y="235" width="18" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button" image="bag" catalog="system"/>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <viewLayoutGuide key="safeArea" id="hhG-XG-10b"/>
@@ -66,6 +78,8 @@
         <image name="Namespace/AppleNamespaced" width="16" height="16"/>
         <image name="Namespace/AppleNonNamespaced" width="16" height="16"/>
         <image name="TypoImage" width="16" height="16"/>
+        <image name="bag" catalog="system" width="64" height="64"/>
+        <image name="grid" catalog="system" width="64" height="56"/>
         <namedColor name="Color">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>


### PR DESCRIPTION
I add also `Button.State` like ImageView. Normally images are also in resources section but in olds storyboard I thinks the section do not exists.

ps: for that IBDecodable has been update to decode `catalog` entry which return "system" for sf symbol
