### PR TITLE
Add Mint to list of possible installation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ A linter tool to normalize `.xib` and `.storyboard` files. Inspired by [realm/Sw
 $ brew install IBDecodable/homebrew-tap/iblinter
 ```
 
+### Using [Mint](https://github.com/yonaskolb/Mint)
+
+```sh
+$ mint install IBDecodable/IBLinter
+```
+
 ### Using [CocoaPods](https://cocoapods.org)
 
 ```sh


### PR DESCRIPTION
This PR adds a tiny bit more documentation under the installation section.

Specifically, I'm happy to say this works with [Mint](https://github.com/yonaskolb/Mint) out of the box.