### PR TITLE
Add support to dynamically pass specific files via command line

### DIFF
--- a/Sources/IBLinterFrontend/Commands/ValidateCommand.swift
+++ b/Sources/IBLinterFrontend/Commands/ValidateCommand.swift
@@ -26,10 +26,13 @@ struct ValidateCommand: CommandProtocol {
             fatalError("\(workDirectoryString) is not directory.")
         }
 
-        let config = Config(options: options) ?? Config.default
+        var config = Config(options: options) ?? Config.default
         if config.disableWhileBuildingForIB &&
             ProcessInfo.processInfo.compiledForInterfaceBuilder {
             return .success(())
+        }
+        if config.included.isEmpty {
+            config.included = options.included
         }
         let validator = Validator()
         let violations = validator.validate(workDirectory: workDirectory, config: config)
@@ -54,12 +57,16 @@ struct ValidateOptions: OptionsProtocol {
     let reporter: String?
     let iblinterFilePath: String?
     let configurationFile: String?
-
-    static func create(_ path: String?) -> (_ reporter: String?) -> (_ script: String?) -> (_ config: String?) -> ValidateOptions {
+    let included: [String]
+    static func create(_ path: String?) -> (_ reporter: String?) -> (_ script: String?) -> (_ config: String?) -> (_ included: String?) -> ValidateOptions {
         return { reporter in
             return { script in
                 return { config in
-                    self.init(path: path, reporter: reporter, iblinterFilePath: script, configurationFile: config)
+                    return { included in
+                        let finalIncluded = included?.split { $0.isNewline || $0 == "," }.map { String($0) }
+                        
+                        return self.init(path: path, reporter: reporter, iblinterFilePath: script, configurationFile: config, included: finalIncluded ?? [])
+                    }
                 }
             }
         }
@@ -71,6 +78,7 @@ struct ValidateOptions: OptionsProtocol {
             <*> mode <| Option(key: "reporter", defaultValue: nil, usage: "the reporter used to log errors and warnings")
             <*> mode <| Option(key: "script", defaultValue: nil, usage: "custom IBLinterfile.swift")
             <*> mode <| Option(key: "config", defaultValue: nil, usage: "the path to IBLint's configuration file")
+            <*> mode <| Option(key: "included", defaultValue: nil, usage: "included files/paths to lint. This is ignored if you specified included paths in your yml configuration file. You can separate paths using `,` or a new line")
     }
 }
 

--- a/Sources/IBLinterKit/Config/Config.swift
+++ b/Sources/IBLinterKit/Config/Config.swift
@@ -12,7 +12,7 @@ public struct Config: Codable {
     public let disabledRules: [String]
     public let enabledRules: [String]
     public let excluded: [String]
-    public let included: [String]
+    public var included: [String]
     public let customModuleRule: [CustomModuleConfig]
     public let useBaseClassRule: [UseBaseClassConfig]
     public let viewAsDeviceRule: ViewAsDeviceConfig?

--- a/Sources/IBLinterKit/Rules/UseBaseClassRule.swift
+++ b/Sources/IBLinterKit/Rules/UseBaseClassRule.swift
@@ -37,7 +37,7 @@ extension Rules {
             let violation: [Violation] = {
                 guard let baseClassesForElement = baseClasses[view.elementClass] else { return [] }
                 guard let customClass = view.customClass else {
-                    let message = "CustomClass is not set to \(viewName(of: view))"
+                    let message = "You must use a subclass of \(viewName(of: view))"
                     return [Violation(pathString: file.pathString, message: message, level: .warning)]
                 }
 

--- a/Sources/IBLinterKit/Validator.swift
+++ b/Sources/IBLinterKit/Validator.swift
@@ -88,6 +88,17 @@ public class Validator {
         func interfaceBuilderFiles(withPatterns patterns: [URL]) -> InterfaceBuilderFiles {
             return patterns.flatMap { globber.expandRecursiveStars(pattern: $0.path) }
                 .reduce(into: InterfaceBuilderFiles()) { result, path in
+                    let url = URL(fileURLWithPath: path)
+                    guard url.hasDirectoryPath else {
+                        switch url.pathExtension {
+                        case "xib": result.xibPaths.insert(url)
+                        case "storyboard": result.storyboardPaths.insert(url)
+                        default:
+                            break
+                        }
+                        return
+                    }
+                    
                     let files = self.interfaceBuilderFiles(atPath: URL(fileURLWithPath: path))
                     result.xibPaths.formUnion(files.xibPaths)
                     result.storyboardPaths.formUnion(files.storyboardPaths)

--- a/Tests/IBLinterKitTest/Utils/LintablePathsTests.swift
+++ b/Tests/IBLinterKitTest/Utils/LintablePathsTests.swift
@@ -50,4 +50,20 @@ class LintablePathsTests: XCTestCase {
 
         XCTAssertEqual(lintablePaths, [])
     }
+    
+    func testIncludedFilePath() {
+        let config = Config(
+            disabledRules: [], enabledRules: [],
+            excluded: [], included: ["Level1_1/Level2_1/Label2_1.xib", "Level1_2"],
+            customModuleRule: [], baseClassRule: [], reporter: ""
+        )
+        let validator = Validator(externalRules: [])
+        let projectPath = fixture.path("Resources/Utils/Glob/ProjectMock")
+        let lintablePaths = validator.lintablePaths(workDirectory: projectPath, config: config).xib
+
+        XCTAssertEqual(
+            lintablePaths.map { $0.path },
+            [projectPath.appendingPathComponent("Level1_1/Level2_1/Label2_1.xib").path, projectPath.appendingPathComponent("Level1_2/Level1_2.xib").path]
+        )
+    }
 }


### PR DESCRIPTION
The use case for this feature is to only lint the files that have been changed. This will help speed up the linting process in certain projects and adds support for a feature offered by SwiftLint, SwiftFormat, and xiblint