### PR TITLE
ci: "Build and Test" workflow should run on pull_request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Run unit tests
-on: push
+on: [push, pull_request]
 jobs:
   test:
     name: Build and Test


### PR DESCRIPTION
test ci workflow should run on pull_request event for non-member.

Refs: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#example-using-a-list-of-events