### PR TITLE
Migrate to homebrew-core

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -3,8 +3,28 @@ on:
   release:
     types: [published]
 jobs:
-  publish:
-    name: Publish
+  publish_brew:
+    name: Publish to Homebrew
+    runs-on: macOS-10.14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Update Homebrew formula
+        run: |
+          brew update
+          pushd $(brew --repository)/Library/Taps/$HOMEBREW_TAP_REPOSITORY
+          git config --local user.name "IBLinter Bot"
+          git config --local user.email $GITHUB_ACTOR@users.noreply.github.com
+          git remote set-url origin https://$GITHUB_ACTOR:$HOMEBREW_GITHUB_API_TOKEN@github.com/$HOMEBREW_TAP_REPOSITORY.git
+          popd
+          git checkout ${GITHUB_REF#refs/heads/}
+          brew bump-formula-pr --tag=$(git describe --tags) --revision=$(git rev-parse HEAD) iblinter
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+          HOMEBREW_TAP_REPOSITORY: homebrew/homebrew-core
+  publish_pods:
+    name: Publish to CocoaPods
     runs-on: macOS-10.14
     steps:
       - name: Checkout
@@ -14,38 +34,6 @@ jobs:
       - name: Upload portable_zip for Release assets
         run: ./script/upload_artifact.sh ./portable_iblinter.zip
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Update Homebrew formula
-        run: |
-          brew tap $HOMEBREW_TAP_REPOSITORY
-          pushd $(brew --repository)/Library/Taps/$HOMEBREW_TAP_REPOSITORY
-          git config --local user.name "IBLinter Bot"
-          git config --local user.email $GITHUB_ACTOR@users.noreply.github.com
-          git remote set-url origin https://$GITHUB_ACTOR:$HOMEBREW_GITHUB_API_TOKEN@github.com/$HOMEBREW_TAP_REPOSITORY.git
-          popd
-          git checkout ${GITHUB_REF#refs/heads/}
-          brew bump-formula-pr --tag=$(git describe --tags) --revision=$(git rev-parse HEAD) iblinter
-
-          pushd $(brew --repository)/Library/Taps/$HOMEBREW_TAP_REPOSITORY
-          FORMULA_PATH=iblinter.rb
-          brew install $FORMULA_PATH --build-bottle
-          brew bottle $FORMULA_PATH --force-core-tap
-
-          BOTTLE=$(find . -name "*.bottle*.tar.gz")
-
-          # Homebrew introduced a change which puts "--" in the bottle name. Rename
-          # the bottle to something that homebrew expects to download/install.
-          mv "$BOTTLE" "${BOTTLE/--/-}"
-          SHA256=$(shasum -a 256 $BOTTLE | cut -f1 -d ' ')
-          ruby utils/replace_bottle_sha256.rb iblinter.rb $SHA256 mojave
-          git commit -am"Update bottle sha256"
-          git push origin HEAD
-
-          $GITHUB_WORKSPACE/script/upload_artifact.sh $BOTTLE
-        env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
-          HOMEBREW_NO_INSTALL_CLEANUP: 1
-          HOMEBREW_TAP_REPOSITORY: IBDecodable/homebrew-tap
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update CocoaPods spec
         run: pod trunk push IBLinter.podspec


### PR DESCRIPTION
Migrate [IBDecodable/homebrew-tap](https://github.com/IBDecodable/homebrew-tap) tap to [homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core/) for maintainability of bottle distribution.

Now, we distributed bottle through CI but it's hard to maintain that script 😢 
In `Homebrew/homebrew-core`, there is a automated bot @BrewTestBot which distributes bottles of multiple OS versions.
So I decided to move IBLinter formula into homebrew-core.

[PR to add formula for `homebrew-core`](https://github.com/Homebrew/homebrew-core/pull/49277)

## Migration plan

ref: https://docs.brew.sh/Migrating-A-Formula-To-A-Tap

1. [x] Put latest stable `iblinter.rb` tagged by 0.4.21 into homebrew-core
2. [x] Put `tap_migrations.json` in `IBDecodable/homebrew-tap` and archive that repo
3. [ ] Merge this PR