### PR TITLE
feat: Add color_resources rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -115,3 +115,12 @@ Check View as: set as a device specified by view_as_device_rule config.
 Check that ReuseIdentifier same as class name.\
 Currently only supported `TableViewCell` and `CollectionViewCell`.
 
+
+## ColorResourcesRule
+
+|    identifier   | `color_resources` |
+|:---------------:|:---------------:|
+|   Default Rule  |  `false` |
+
+Check if named color resources are valid.
+

--- a/Sources/IBLinterKit/Entity/AssetsCatalog.swift
+++ b/Sources/IBLinterKit/Entity/AssetsCatalog.swift
@@ -27,15 +27,19 @@ extension AssetsCatalog {
             }) ?? []
     }
 
+    func entryValues(for item: Item) -> [String] {
+        return entries.flatMap { $0.values(for: item) }
+    }
+
     private enum Constants {
         static let path = "Contents.json"
         static let properties = "properties"
         static let providesNamespace = "provides-namespace"
+    }
 
-        enum Item: String {
-            case colorSet = "colorset"
-            case imageSet = "imageset"
-        }
+    enum Item: String {
+        case colorSet = "colorset"
+        case imageSet = "imageset"
     }
 
     enum Entry: Equatable {
@@ -47,7 +51,7 @@ extension AssetsCatalog {
             guard FileManager.default.isDirectory(path) else { return nil }
             let type = path.extension ?? ""
 
-            switch Constants.Item(rawValue: type) {
+            switch Item(rawValue: type) {
             case .colorSet?:
                 let name = path.lastComponentWithoutExtension
                 self = .color(name: name, value: "\(prefix)\(name)")
@@ -86,6 +90,17 @@ extension AssetsCatalog {
             }
 
             return (json as? [String: Any]) ?? [:]
+        }
+
+        fileprivate func values(for item: Item) -> [String] {
+            switch self {
+            case .group(_, let items):
+                return items.flatMap { $0.values(for: item) }
+            case .color(_, let value):
+                return item == .colorSet ? [value] : []
+            case .image(_, let value):
+                return item == .imageSet ? [value] : []
+            }
         }
     }
 }

--- a/Sources/IBLinterKit/Rule.swift
+++ b/Sources/IBLinterKit/Rule.swift
@@ -36,7 +36,8 @@ public struct Rules {
             UseBaseClassRule.self,
             AmbiguousViewRule.self,
             ViewAsDeviceRule.self,
-            ReuseIdentifierRule.self
+            ReuseIdentifierRule.self,
+            ColorResourcesRule.self
         ]
     }()
 

--- a/Sources/IBLinterKit/Rules/ColorResourcesRule.swift
+++ b/Sources/IBLinterKit/Rules/ColorResourcesRule.swift
@@ -1,0 +1,71 @@
+import Foundation
+import IBDecodable
+
+extension Rules {
+
+    struct ColorResourcesRule: Rule {
+
+        static let identifier = "color_resources"
+        static let description = "Check if named color resources are valid."
+
+        let assetsCatalogs: [AssetsCatalog]
+
+        public init(context: Context) {
+            let paths = glob(pattern: context.workDirectory.appendingPathComponent("**/*.xcassets").path)
+            let excluded = context.config.excluded.flatMap { glob(pattern: "\($0)/**/*.xcassets") }
+            let lintablePaths = paths.filter { !excluded.map { $0.absoluteString }.contains($0.absoluteString) }
+            self.init(catalogs: lintablePaths.map { AssetsCatalog.init(path: $0.relativePath) })
+        }
+
+        init(catalogs: [AssetsCatalog]) {
+            self.assetsCatalogs = catalogs
+        }
+
+        func validate(xib: XibFile) -> [Violation] {
+            return validate(
+                for: xib.document.children(of: NamedColor.self),
+                file: xib
+            )
+        }
+
+        func validate(storyboard: StoryboardFile) -> [Violation] {
+            return validate(
+                for: storyboard.document.children(of: NamedColor.self),
+                file: storyboard
+            )
+        }
+
+        private func validate<T: InterfaceBuilderFile>(for colors: [NamedColor], file: T) -> [Violation] {
+            let catalogAssetNames = assetsCatalogs.flatMap { $0.values }
+            return colors
+                .map { $0.name }
+                .filter { !catalogAssetNames.contains($0) }
+                .map {
+                    Violation(
+                        pathString: file.pathString,
+                        message: "\($0) not found",
+                        level: .error)
+            }
+        }
+    }
+}
+
+private extension AssetsCatalog {
+    // namespaced names of the
+    var values: [String] {
+        return entries.flatMap { $0.values }
+    }
+}
+
+private extension AssetsCatalog.Entry {
+    var values: [String] {
+        switch self {
+        case .group(_, let items):
+            return items.flatMap { $0.values }
+        case .color(_, let value):
+            return [value]
+        case .image(_, let value):
+            return [value]
+        }
+    }
+}

--- a/Sources/IBLinterKit/Rules/ColorResourcesRule.swift
+++ b/Sources/IBLinterKit/Rules/ColorResourcesRule.swift
@@ -36,7 +36,7 @@ extension Rules {
         }
 
         private func validate<T: InterfaceBuilderFile>(for colors: [NamedColor], file: T) -> [Violation] {
-            let catalogAssetNames = assetsCatalogs.flatMap { $0.values }
+            let catalogAssetNames = assetsCatalogs.flatMap { $0.entryValues(for: .colorSet) }
             return colors
                 .map { $0.name }
                 .filter { !catalogAssetNames.contains($0) }
@@ -46,26 +46,6 @@ extension Rules {
                         message: "\($0) not found",
                         level: .error)
             }
-        }
-    }
-}
-
-private extension AssetsCatalog {
-    // namespaced names of the
-    var values: [String] {
-        return entries.flatMap { $0.values }
-    }
-}
-
-private extension AssetsCatalog.Entry {
-    var values: [String] {
-        switch self {
-        case .group(_, let items):
-            return items.flatMap { $0.values }
-        case .color(_, let value):
-            return [value]
-        case .image:
-            return []
         }
     }
 }

--- a/Sources/IBLinterKit/Rules/ColorResourcesRule.swift
+++ b/Sources/IBLinterKit/Rules/ColorResourcesRule.swift
@@ -64,8 +64,8 @@ private extension AssetsCatalog.Entry {
             return items.flatMap { $0.values }
         case .color(_, let value):
             return [value]
-        case .image(_, let value):
-            return [value]
+        case .image:
+            return []
         }
     }
 }

--- a/Sources/IBLinterKit/Rules/ImageResourcesRule.swift
+++ b/Sources/IBLinterKit/Rules/ImageResourcesRule.swift
@@ -52,7 +52,7 @@ extension Rules {
         }
 
         private func validate<T: InterfaceBuilderFile>(for images: [Image], imageViews: [ImageView], states: [Button.State], file: T) -> [Violation] {
-            let catalogAssetNames = assetsCatalogs.flatMap { $0.values }
+            let catalogAssetNames = assetsCatalogs.flatMap { $0.entryValues(for: .imageSet) }
             let xcodeprojAssetNames = xcodeproj.flatMap {
                 $0.pbxproj.fileReferences.compactMap {
                     $0.name
@@ -70,26 +70,6 @@ extension Rules {
                         message: "\($0) not found",
                         level: .error)
                 }
-        }
-    }
-}
-
-private extension AssetsCatalog {
-    // namespaced names of the
-    var values: [String] {
-        return entries.flatMap { $0.values }
-    }
-}
-
-private extension AssetsCatalog.Entry {
-    var values: [String] {
-        switch self {
-        case .group(_, let items):
-            return items.flatMap { $0.values }
-        case .color(_, let value):
-            return [value]
-        case .image(_, let value):
-            return [value]
         }
     }
 }

--- a/Tests/IBLinterKitTest/Resources/Rules/ColorResourcesRule/ColorResources.xib
+++ b/Tests/IBLinterKitTest/Resources/Rules/ColorResourcesRule/ColorResources.xib
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" name="MyTestColor"/>
+            <color key="tintColor" name="ColorResourcesTestColor"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="139" y="153"/>
+        </view>
+    </objects>
+    <resources>
+        <namedColor name="ColorResourcesTestColor">
+            <color red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="MyTestColor">
+            <color red="0.0" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/Tests/IBLinterKitTest/Resources/Rules/ColorResourcesRule/Colors.xcassets/ColorResourcesTestColor.colorset/Contents.json
+++ b/Tests/IBLinterKitTest/Resources/Rules/ColorResourcesRule/Colors.xcassets/ColorResourcesTestColor.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.000",
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.000",
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.000",
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Tests/IBLinterKitTest/Resources/Rules/ColorResourcesRule/Colors.xcassets/Contents.json
+++ b/Tests/IBLinterKitTest/Resources/Rules/ColorResourcesRule/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Tests/IBLinterKitTest/Resources/Rules/ColorResourcesRule/Colors.xcassets/MyTestColor.imageset/Contents.json
+++ b/Tests/IBLinterKitTest/Resources/Rules/ColorResourcesRule/Colors.xcassets/MyTestColor.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Tests/IBLinterKitTest/Rules/ColorResourcesRuleTests.swift
+++ b/Tests/IBLinterKitTest/Rules/ColorResourcesRuleTests.swift
@@ -1,0 +1,15 @@
+@testable import IBLinterKit
+import XCTest
+
+class ColorResourcesRuleTests: XCTestCase {
+
+    let fixture = Fixture()
+
+    func testColorResources() {
+        let url = fixture.path("Resources/Rules/ColorResourcesRule/ColorResources.xib")
+        let assetURL = fixture.path("Resources/Rules/ColorResourcesRule/Colors.xcassets")
+        let rule = Rules.ColorResourcesRule(catalogs: [.init(path: assetURL.path)])
+        let violations = try! rule.validate(xib: .init(url: url))
+        XCTAssertEqual(violations.count, 1)
+    }
+}


### PR DESCRIPTION
This rule is for detect missing named colors similar to `image_resources` rule.

<img width="312" alt="スクリーンショット 2020-01-27 14 12 17" src="https://user-images.githubusercontent.com/425216/73151569-11f7f880-410f-11ea-8d4f-3a27eea8ea4d.png">
