### PR TITLE
feat: reuse_identifier rule support UICollectionReusableView

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,9 +23,9 @@
         "package": "IBDecodable",
         "repositoryURL": "https://github.com/IBDecodable/IBDecodable.git",
         "state": {
-          "branch": null,
-          "revision": "eef5f041aba7b2a90a366d281184155b0b9d4e2f",
-          "version": "0.1.0"
+          "branch": "master",
+          "revision": "b8cf52138805d971c3b2a2a54d8555d3bbaa5b6f",
+          "version": null
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,9 +23,9 @@
         "package": "IBDecodable",
         "repositoryURL": "https://github.com/IBDecodable/IBDecodable.git",
         "state": {
-          "branch": "master",
+          "branch": null,
           "revision": "b8cf52138805d971c3b2a2a54d8555d3bbaa5b6f",
-          "version": null
+          "version": "0.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -21,9 +21,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        // this changes are WIP until release of next version of IBDecodable.
-        .package(url: "https://github.com/IBDecodable/IBDecodable.git", ._branchItem("master")),
-//        .package(url: "https://github.com/IBDecodable/IBDecodable.git", from: "0.1.0"),
+        .package(url: "https://github.com/IBDecodable/IBDecodable.git", from: "0.2.0"),
         .package(url: "https://github.com/Carthage/Commandant.git", .upToNextMinor(from: "0.16.0")),
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.22.0"),
         .package(url: "https://github.com/xcodeswift/xcproj.git", from: "6.6.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,9 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBDecodable/IBDecodable.git", from: "0.1.0"),
+        // this changes are WIP until release of next version of IBDecodable.
+        .package(url: "https://github.com/IBDecodable/IBDecodable.git", ._branchItem("master")),
+//        .package(url: "https://github.com/IBDecodable/IBDecodable.git", from: "0.1.0"),
         .package(url: "https://github.com/Carthage/Commandant.git", .upToNextMinor(from: "0.16.0")),
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.22.0"),
         .package(url: "https://github.com/xcodeswift/xcproj.git", from: "6.6.0"),

--- a/Rules.md
+++ b/Rules.md
@@ -112,8 +112,7 @@ Check View as: set as a device specified by view_as_device_rule config.
 |:---------------:|:---------------:|
 |   Default Rule  |  `false` |
 
-Check that ReuseIdentifier same as class name.\
-Currently only supported `TableViewCell` and `CollectionViewCell`.
+Check that ReuseIdentifier same as class name.
 
 
 ## ColorResourcesRule

--- a/Sources/IBLinterKit/Rules/ReuseIdentifierRule.swift
+++ b/Sources/IBLinterKit/Rules/ReuseIdentifierRule.swift
@@ -5,10 +5,7 @@ extension Rules {
     struct ReuseIdentifierRule: Rule {
 
         static let identifier = "reuse_identifier"
-        static let description = """
-Check that ReuseIdentifier same as class name.\\
-Currently only supported `TableViewCell` and `CollectionViewCell`.
-"""
+        static let description = " Check that ReuseIdentifier same as class name."
 
         init(context: Context) {}
 
@@ -25,14 +22,17 @@ Currently only supported `TableViewCell` and `CollectionViewCell`.
 
         private func validate<T: InterfaceBuilderFile>(for view: ViewProtocol, file: T) -> [Violation] {
             let violation: [Violation] = {
-                // Currently only supported TableViewCell and CollectionViewCell
-                // UICollectionReusableView will be support after IBDecodable support its view.
                 // MKAnnotationView is not yet supported by interfacebuilder.
                 var reusableCells = [IBReusable & ViewProtocol]()
                 if let tableView = view as? TableView, let cells = tableView.prototypeCells {
                     reusableCells += cells
-                } else if let collectionView = view as? CollectionView, let cells = collectionView.cells {
-                    reusableCells += cells
+                } else if let collectionView = view as? CollectionView {
+                    if let cells = collectionView.cells {
+                        reusableCells += cells
+                    }
+                    if let views = collectionView.collectionReusableViews {
+                        reusableCells += views
+                    }
                 } else if let cell = view as? IBReusable & ViewProtocol {
                     reusableCells += [cell]
                 }

--- a/Tests/IBLinterKitTest/Resources/Rules/ReuseIdentifierRule/ReuseIdentifier.storyboard
+++ b/Tests/IBLinterKitTest/Resources/Rules/ReuseIdentifierRule/ReuseIdentifier.storyboard
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -24,7 +21,7 @@
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="crt-6w-H8j" customClass="TestTableViewCell">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="crt-6w-H8j" id="8A8-Ea-hou">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -54,10 +51,10 @@
                             <tableViewSection id="UbO-vh-sM8">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="6s3-Rv-XOH">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="6s3-Rv-XOH" id="ahP-wS-sUH">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -88,13 +85,13 @@
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="pvp-pc-zJo">
                                     <size key="itemSize" width="50" height="50"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="headerReferenceSize" width="50" height="50"/>
                                     <size key="footerReferenceSize" width="50" height="50"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="NCI-K4-kKB" customClass="TestCollectionViewCell">
-                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                        <rect key="frame" x="0.0" y="50" width="50" height="50"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
                                             <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -102,8 +99,12 @@
                                         </view>
                                     </collectionViewCell>
                                 </cells>
-                                <collectionReusableView key="sectionFooterView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="qU9-aa-h8f" customClass="TestCollectionReusableView">
-                                    <rect key="frame" x="0.0" y="50" width="375" height="50"/>
+                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="guj-gH-onF" customClass="TestHeaderCollectionReusableView">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                </collectionReusableView>
+                                <collectionReusableView key="sectionFooterView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="qU9-aa-h8f" customClass="TestFooterCollectionReusableView">
+                                    <rect key="frame" x="0.0" y="100" width="375" height="50"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 </collectionReusableView>
                             </collectionView>

--- a/Tests/IBLinterKitTest/Resources/Rules/ReuseIdentifierRule/ReuseIdentifier.storyboard
+++ b/Tests/IBLinterKitTest/Resources/Rules/ReuseIdentifierRule/ReuseIdentifier.storyboard
@@ -71,10 +71,10 @@
             </objects>
             <point key="canvasLocation" x="-660" y="-122"/>
         </scene>
-        <!--View Controller-->
+        <!--Invalid View Controller-->
         <scene sceneID="O5T-4u-qPV">
             <objects>
-                <viewController id="Jwh-xL-35B" sceneMemberID="viewController">
+                <viewController id="Jwh-xL-35B" customClass="InvalidViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="jRs-xq-LDO">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -116,6 +116,52 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zVa-d2-x2T" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-26" y="-123"/>
+        </scene>
+        <!--Valid View Controller-->
+        <scene sceneID="QaR-dn-HzV">
+            <objects>
+                <viewController id="soj-M7-Xec" customClass="ValidViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="d5N-u5-xB1">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="i81-CH-qUR">
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="CqZ-vi-FcD">
+                                    <size key="itemSize" width="50" height="50"/>
+                                    <size key="headerReferenceSize" width="50" height="50"/>
+                                    <size key="footerReferenceSize" width="50" height="50"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ValidCollectionViewCell" id="gA3-Gh-Mua" customClass="ValidCollectionViewCell">
+                                        <rect key="frame" x="0.0" y="50" width="50" height="50"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
+                                            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </view>
+                                    </collectionViewCell>
+                                </cells>
+                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ValidHeaderCollectionReusableView" id="oam-O7-nye" customClass="ValidHeaderCollectionReusableView">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                </collectionReusableView>
+                                <collectionReusableView key="sectionFooterView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ValidFooterCollectionReusableView" id="L7a-hl-sUF" customClass="ValidFooterCollectionReusableView">
+                                    <rect key="frame" x="0.0" y="100" width="375" height="50"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                </collectionReusableView>
+                            </collectionView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="EjM-jp-tdd"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="jRp-sm-UuI" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="610" y="-123"/>
         </scene>
     </scenes>
 </document>

--- a/Tests/IBLinterKitTest/Resources/Rules/ReuseIdentifierRule/ReuseIdentifier.xib
+++ b/Tests/IBLinterKitTest/Resources/Rules/ReuseIdentifierRule/ReuseIdentifier.xib
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,10 +13,19 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gPV-Kt-cGF" id="4bg-zz-u7M">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
             </tableViewCellContentView>
             <point key="canvasLocation" x="132" y="-72"/>
+        </tableViewCell>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="XibValidTableViewCell" id="LFc-mj-12t" customClass="XibValidTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LFc-mj-12t" id="4gv-Op-HcK">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <point key="canvasLocation" x="839" y="-73"/>
         </tableViewCell>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="Fcy-fF-WnG" customClass="XibTestCollectionViewCell">
             <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -36,6 +42,22 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <viewLayoutGuide key="safeArea" id="T7Z-nz-2h1"/>
             <point key="canvasLocation" x="124" y="113"/>
+        </collectionReusableView>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="XibValidCollectionViewCell" id="JME-ow-ym7" customClass="XibValidCollectionViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
+                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </view>
+            <viewLayoutGuide key="safeArea" id="TRK-Wc-EEK"/>
+            <point key="canvasLocation" x="578" y="22"/>
+        </collectionViewCell>
+        <collectionReusableView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="XibValidCollectionReusableView" id="kMX-Em-Ovh" customClass="XibValidCollectionReusableView">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <viewLayoutGuide key="safeArea" id="MAd-mP-nbD"/>
+            <point key="canvasLocation" x="838" y="112"/>
         </collectionReusableView>
     </objects>
 </document>

--- a/Tests/IBLinterKitTest/Rules/ReuseIdentifierRuleTests.swift
+++ b/Tests/IBLinterKitTest/Rules/ReuseIdentifierRuleTests.swift
@@ -10,13 +10,13 @@ class ReuseIdentifierRuleTests: XCTestCase {
         let url = fixture.path("Resources/Rules/ReuseIdentifierRule/ReuseIdentifier.storyboard")
         let rule = Rules.ReuseIdentifierRule(context: .mock(from: .default))
         let violations = try! rule.validate(storyboard: StoryboardFile(url: url))
-        XCTAssertEqual(violations.count, 2)
+        XCTAssertEqual(violations.count, 4)
     }
     
     func testReuseIdentifierXib() {
         let url = fixture.path("Resources/Rules/ReuseIdentifierRule/ReuseIdentifier.xib")
         let rule = Rules.ReuseIdentifierRule(context: .mock(from: .default))
         let violations = try! rule.validate(xib: XibFile(url: url))
-        XCTAssertEqual(violations.count, 2)
+        XCTAssertEqual(violations.count, 3)
     }
 }


### PR DESCRIPTION
Hi @kateinoigakukun and @phimage.

Latest IBDecodable supported decode feature of UICollectionReusableView.
This PR use it to support UICollectionReusableView in `reuse_identifier` rule.

~NOTE: IBDecodable not yet released as tagged version, I'll change back package dependency files after the release. That is reason I add `"WIP"` to PR title, but all other work are finished please review except it~
`0.2.0` is not available 👍 

### Detail changes description

- `reuse_identifier` rule support UICollectionReusableView.
- fixed unit test.
- modify storyboard fixture resource to test header and footer UICollectionReusableView.
