### PR TITLE
Update dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tadija/AEXML",
         "state": {
           "branch": null,
-          "revision": "54bb8ea6fb693dd3f92a89e5fcc19e199fdeedd0",
-          "version": "4.3.3"
+          "revision": "e4d517844dd03dac557e35d77a8e9ab438de91a6",
+          "version": "4.4.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Carthage/Commandant.git",
         "state": {
           "branch": null,
-          "revision": "2cd0210f897fe46c6ce42f52ccfa72b3bbb621a0",
-          "version": "0.16.0"
+          "revision": "ab68611013dec67413628ac87c1f29e8427bc8e4",
+          "version": "0.17.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/IBDecodable/IBDecodable.git",
         "state": {
           "branch": null,
-          "revision": "213da3d6cf87d1f21813e9ae778377b4586503eb",
-          "version": "0.3.0"
+          "revision": "804c5f3dcf290c019b25e0ce2e1044d3a02c185a",
+          "version": "0.4.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "43304bf2b1579fd555f2fdd51742771c1e4f2b98",
-          "version": "8.0.1"
+          "revision": "7fd118ec8795888bcbbebc1a41f6984454c4cd6f",
+          "version": "8.0.7"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit",
         "state": {
           "branch": null,
-          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
-          "version": "0.9.2"
+          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
+          "version": "1.0.0"
         }
       },
       {
@@ -51,17 +51,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "94df9b449508344667e5afc7e80f8bcbff1e4c37",
-          "version": "2.1.0"
-        }
-      },
-      {
-        "package": "Result",
-        "repositoryURL": "https://github.com/antitypical/Result.git",
-        "state": {
-          "branch": null,
-          "revision": "2ca499ba456795616fbc471561ff1d963e6ae160",
-          "version": "4.1.0"
+          "revision": "33682c2f6230c60614861dfc61df267e11a1602f",
+          "version": "2.2.0"
         }
       },
       {
@@ -69,8 +60,8 @@
         "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
         "state": {
           "branch": null,
-          "revision": "fd9091759201473aa234c22322a3939615aef59a",
-          "version": "0.23.2"
+          "revision": "77a4dbbb477a8110eb8765e3c44c70fb4929098f",
+          "version": "0.29.0"
         }
       },
       {
@@ -83,30 +74,30 @@
         }
       },
       {
-        "package": "SwiftShell",
-        "repositoryURL": "https://github.com/kareman/SwiftShell",
-        "state": {
-          "branch": null,
-          "revision": "beebe43c986d89ea5359ac3adcb42dac94e5e08a",
-          "version": "4.1.2"
-        }
-      },
-      {
         "package": "SWXMLHash",
         "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
         "state": {
           "branch": null,
-          "revision": "f43166a8e18fdd0857f29e303b1bb79a5428bca0",
-          "version": "4.9.0"
+          "revision": "a4931e5c3bafbedeb1601d3bb76bbe835c6d475a",
+          "version": "5.0.1"
         }
       },
       {
-        "package": "xcodeproj",
-        "repositoryURL": "https://github.com/xcodeswift/xcproj.git",
+        "package": "XcodeProj",
+        "repositoryURL": "https://github.com/tuist/XcodeProj.git",
         "state": {
           "branch": null,
-          "revision": "065f348754b6155b8037dc43876a8f2ee354b95d",
-          "version": "6.7.0"
+          "revision": "912d40cc2ea4a300eff6dd7c6a10b4f4dedbcbec",
+          "version": "7.10.0"
+        }
+      },
+      {
+        "package": "XcodeProjCExt",
+        "repositoryURL": "https://github.com/tuist/XcodeProjCExt",
+        "state": {
+          "branch": null,
+          "revision": "21a510c225ff2bc83d5920a21d902af4b1e7e218",
+          "version": "0.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,10 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBDecodable/IBDecodable.git", from: "0.3.0"),
-        .package(url: "https://github.com/Carthage/Commandant.git", .upToNextMinor(from: "0.16.0")),
-        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.22.0"),
-        .package(url: "https://github.com/xcodeswift/xcproj.git", from: "6.6.0"),
+        .package(url: "https://github.com/IBDecodable/IBDecodable.git", from: "0.4.0"),
+        .package(url: "https://github.com/Carthage/Commandant.git", .upToNextMinor(from: "0.17.0")),
+        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.29.0"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", from: "7.10.0"),
     ],
     targets: [
         .target(
@@ -39,7 +39,7 @@ let package = Package(
             name: "IBLinterKit",
             dependencies: [
                 "IBDecodable", "Commandant",
-                "SourceKittenFramework", "xcodeproj"
+                "SourceKittenFramework", "XcodeProj"
             ]
         ),
         .target(

--- a/Sources/IBLinterFrontend/Commands/ValidateCommand.swift
+++ b/Sources/IBLinterFrontend/Commands/ValidateCommand.swift
@@ -5,7 +5,6 @@
 //  Created by SaitoYuta on 2017/12/13.
 //
 
-import Result
 import Foundation
 import IBDecodable
 import IBLinterKit

--- a/Sources/IBLinterFrontend/Commands/VersionCommand.swift
+++ b/Sources/IBLinterFrontend/Commands/VersionCommand.swift
@@ -5,7 +5,6 @@
 //  Created by SaitoYuta on 2018/05/17.
 //
 
-import Result
 import Commandant
 import IBLinterKit
 

--- a/Sources/IBLinterKit/Rules/CustomModuleRule.swift
+++ b/Sources/IBLinterKit/Rules/CustomModuleRule.swift
@@ -8,7 +8,7 @@
 import Foundation
 import IBDecodable
 import SourceKittenFramework
-import xcodeproj
+import XcodeProj
 
 private extension XibFile {
   var fileExtension: String {

--- a/Sources/IBLinterKit/Rules/ImageResourcesRule.swift
+++ b/Sources/IBLinterKit/Rules/ImageResourcesRule.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import IBDecodable
-import xcodeproj
+import XcodeProj
 
 extension Rules {
 

--- a/Sources/Tools/DumpRuleDocument.swift
+++ b/Sources/Tools/DumpRuleDocument.swift
@@ -6,7 +6,6 @@
 //
 
 import Commandant
-import Result
 import IBLinterKit
 import Darwin
 


### PR DESCRIPTION
Use of the latest IBDecodable
Because of dependency graph, the others must be updated too

Then `xcodeswift/xcproj` seems to have been renamed to `tuist/XcodeProj`
because of this dependency the project is not yet buildable on linux
there is some C code, AEXML, .. (there is an issue on project

I have made mine https://github.com/phimage/XcodeProjKit buildable on linux
I will try to use it with iblinter and check the performance