### PR TITLE
Feature/linux

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "AEXML",
-        "repositoryURL": "https://github.com/tadija/AEXML",
-        "state": {
-          "branch": null,
-          "revision": "e4d517844dd03dac557e35d77a8e9ab438de91a6",
-          "version": "4.4.0"
-        }
-      },
-      {
         "package": "Commandant",
         "repositoryURL": "https://github.com/Carthage/Commandant.git",
         "state": {
@@ -38,15 +29,6 @@
         }
       },
       {
-        "package": "PathKit",
-        "repositoryURL": "https://github.com/kylef/PathKit",
-        "state": {
-          "branch": null,
-          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
-          "version": "1.0.0"
-        }
-      },
-      {
         "package": "Quick",
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
@@ -65,15 +47,6 @@
         }
       },
       {
-        "package": "Spectre",
-        "repositoryURL": "https://github.com/kylef/Spectre.git",
-        "state": {
-          "branch": null,
-          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
-          "version": "0.9.0"
-        }
-      },
-      {
         "package": "SWXMLHash",
         "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
         "state": {
@@ -83,21 +56,12 @@
         }
       },
       {
-        "package": "XcodeProj",
-        "repositoryURL": "https://github.com/tuist/XcodeProj.git",
+        "package": "XcodeProjKit",
+        "repositoryURL": "https://github.com/phimage/XcodeProjKit.git",
         "state": {
           "branch": null,
-          "revision": "912d40cc2ea4a300eff6dd7c6a10b4f4dedbcbec",
-          "version": "7.10.0"
-        }
-      },
-      {
-        "package": "XcodeProjCExt",
-        "repositoryURL": "https://github.com/tuist/XcodeProjCExt",
-        "state": {
-          "branch": null,
-          "revision": "21a510c225ff2bc83d5920a21d902af4b1e7e218",
-          "version": "0.1.0"
+          "revision": "1fc861d368831f751341f804298e78ebb789592e",
+          "version": "2.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 
 import PackageDescription
 
-let package = Package(
+var package = Package(
     name: "IBLinter",
     platforms: [.macOS(.v10_11)],
     products: [
@@ -55,3 +55,8 @@ let package = Package(
         ),
     ]
 )
+
+#if os(Linux)
+package.dependencies.append(.package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"))
+package.targets[2].dependencies.append("Crypto")
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/IBDecodable/IBDecodable.git", from: "0.4.0"),
         .package(url: "https://github.com/Carthage/Commandant.git", .upToNextMinor(from: "0.17.0")),
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.29.0"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", from: "7.10.0"),
+        .package(url: "https://github.com/phimage/XcodeProjKit.git", from: "2.2.0"),
     ],
     targets: [
         .target(
@@ -39,7 +39,7 @@ let package = Package(
             name: "IBLinterKit",
             dependencies: [
                 "IBDecodable", "Commandant",
-                "SourceKittenFramework", "XcodeProj"
+                "SourceKittenFramework", "XcodeProjKit"
             ]
         ),
         .target(

--- a/Sources/IBLinterFrontend/Commands/ValidateCommand.swift
+++ b/Sources/IBLinterFrontend/Commands/ValidateCommand.swift
@@ -9,7 +9,6 @@ import Foundation
 import IBDecodable
 import IBLinterKit
 import Commandant
-import PathKit
 
 struct ValidateCommand: CommandProtocol {
     typealias Options = ValidateOptions

--- a/Sources/IBLinterKit/Rules/CustomModuleRule.swift
+++ b/Sources/IBLinterKit/Rules/CustomModuleRule.swift
@@ -8,7 +8,6 @@
 import Foundation
 import IBDecodable
 import SourceKittenFramework
-import XcodeProj
 
 private extension XibFile {
   var fileExtension: String {

--- a/Sources/IBLinterKit/Rules/ImageResourcesRule.swift
+++ b/Sources/IBLinterKit/Rules/ImageResourcesRule.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import IBDecodable
-import XcodeProj
+import XcodeProjKit
 
 extension Rules {
 
@@ -29,7 +29,7 @@ extension Rules {
         init(catalogs: [AssetsCatalog]) {
             self.assetsCatalogs = catalogs
             self.xcodeproj = glob(pattern: "*.xcodeproj").compactMap {
-                try? XcodeProj.init(pathString: $0.path)
+                try? XcodeProj(url: $0)
             }
         }
 
@@ -54,7 +54,7 @@ extension Rules {
         private func validate<T: InterfaceBuilderFile>(for images: [Image], imageViews: [ImageView], states: [Button.State], file: T) -> [Violation] {
             let catalogAssetNames = assetsCatalogs.flatMap { $0.entryValues(for: .imageSet, .symbolSet) }
             let xcodeprojAssetNames = xcodeproj.flatMap {
-                $0.pbxproj.fileReferences.compactMap {
+                $0.fileReferences.compactMap {
                     $0.name
                 }
             }
@@ -71,5 +71,11 @@ extension Rules {
                         level: .error)
                 }
         }
+    }
+}
+
+extension XcodeProj {
+    var fileReferences: [PBXFileReference] {
+        return objects.dict.values.compactMap({ $0 as? PBXFileReference })
     }
 }

--- a/Sources/Tools/DumpRuleDocument.swift
+++ b/Sources/Tools/DumpRuleDocument.swift
@@ -7,7 +7,11 @@
 
 import Commandant
 import IBLinterKit
+#if os(Linux)
+import Glibc
+#else
 import Darwin
+#endif
 
 struct DumpRuleDocument: CommandProtocol {
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,1 @@
+fatalError("Use `swift test --enable-test-discovery` to run tests")


### PR DESCRIPTION
- fix import
- change project to decode Xcode Project
  - a lot faster, 0.2s become 0.03s using native plist decoder
    - and could be better if activate a compile flag LAZY to have read only structure with lazy loading of fields
  - the code could be imported instead of making dependencies if we do want all the project feature (but with this change a lot of code has been removed PathKit, AEXML, ...)
- add missing linux main for test

There is still an issue with sha1 in LintCache