### PR TITLE
Add UseTraitCollections rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You can configure `use_trait_collections rule by `UseTraitCollectionsConfig`. If
 
 |    key   | description |
 |:---------------:|:---------------:|
-|   use_trait_collections  |  `true` |
+|   enabled  |  `true` |
 
 
 ```yaml
@@ -174,5 +174,5 @@ use_base_class_rule:
 view_as_device_rule:
   device_id: retina4_0
 use_trait_collections_rule:
-  use_trait_collections: true
+  enabled: false
 ```

--- a/README.md
+++ b/README.md
@@ -140,10 +140,19 @@ You can configure `view_as_device` rule by `ViewAsDeviceConfig`. If there are no
 | `iPhone XR`       | `retina6_1`          |
 | `iPhone XS Max`   | `retina6_5`          |
 
+### UseTraitCollectionsConfig
+
+You can configure `use_trait_collections rule by `UseTraitCollectionsConfig`. If there is no config then use_trait_collections is set to true
+
+|    key   | description |
+|:---------------:|:---------------:|
+|   use_trait_collections  |  `true` |
+
 
 ```yaml
 enabled_rules:
   - relative_to_margin
+  - use_trait_collections
 disabled_rules:
   - custom_class_name
 excluded:
@@ -164,4 +173,6 @@ use_base_class_rule:
       - SecondaryLabel
 view_as_device_rule:
   device_id: retina4_0
+use_trait_collections_rule:
+  use_trait_collections: true
 ```

--- a/Rules.md
+++ b/Rules.md
@@ -131,3 +131,11 @@ Check that ReuseIdentifier same as class name.
 |   Default Rule  |  `false` |
 
 Check if named color resources are valid.
+
+## UseTraitCollectionsRule
+
+|    identifier   | `use_trait_collections` |
+|:---------------:|:---------------:|
+|   Default Rule  |  `false` |
+
+Check if a document useTraitCollections is enabled or disabled

--- a/Sources/IBLinterKit/Config/Config.swift
+++ b/Sources/IBLinterKit/Config/Config.swift
@@ -16,6 +16,7 @@ public struct Config: Codable {
     public let customModuleRule: [CustomModuleConfig]
     public let useBaseClassRule: [UseBaseClassConfig]
     public let viewAsDeviceRule: ViewAsDeviceConfig?
+    public let useTraitCollectionsRule: UseTraitCollectionsConfig?
     public let reporter: String
     public let disableWhileBuildingForIB: Bool
     public let ignoreCache: Bool
@@ -28,6 +29,7 @@ public struct Config: Codable {
         case customModuleRule = "custom_module_rule"
         case useBaseClassRule = "use_base_class_rule"
         case viewAsDeviceRule = "view_as_device_rule"
+        case useTraitCollectionsRule = "use_trait_collections_rule"
         case reporter = "reporter"
         case disableWhileBuildingForIB = "disable_while_building_for_ib"
         case ignoreCache = "ignore_cache"
@@ -44,6 +46,7 @@ public struct Config: Codable {
         customModuleRule = []
         useBaseClassRule = []
         viewAsDeviceRule = nil
+        useTraitCollectionsRule = nil
         reporter = "xcode"
         disableWhileBuildingForIB = true
         ignoreCache = false
@@ -54,6 +57,7 @@ public struct Config: Codable {
          customModuleRule: [CustomModuleConfig] = [],
          baseClassRule: [UseBaseClassConfig] = [],
          viewAsDeviceRule: ViewAsDeviceConfig? = nil,
+         useTraitCollectionsRule: UseTraitCollectionsConfig? = nil,
          reporter: String = "xcode", disableWhileBuildingForIB: Bool = true,
          ignoreCache: Bool = false) {
         self.disabledRules = disabledRules
@@ -62,6 +66,7 @@ public struct Config: Codable {
         self.included = included
         self.customModuleRule = customModuleRule
         self.useBaseClassRule = baseClassRule
+        self.useTraitCollectionsRule = useTraitCollectionsRule
         self.viewAsDeviceRule = viewAsDeviceRule
         self.reporter = reporter
         self.disableWhileBuildingForIB = disableWhileBuildingForIB
@@ -76,6 +81,7 @@ public struct Config: Codable {
         included = try container.decodeIfPresent(Optional<[String]>.self, forKey: .included).flatMap { $0 } ?? []
         customModuleRule = try container.decodeIfPresent(Optional<[CustomModuleConfig]>.self, forKey: .customModuleRule).flatMap { $0 } ?? []
         useBaseClassRule = try container.decodeIfPresent(Optional<[UseBaseClassConfig]>.self, forKey: .useBaseClassRule)?.flatMap { $0 } ?? []
+        useTraitCollectionsRule = try container.decodeIfPresent(Optional<UseTraitCollectionsConfig>.self, forKey: .useTraitCollectionsRule) ?? nil
         viewAsDeviceRule = try container.decodeIfPresent(Optional<ViewAsDeviceConfig>.self, forKey: .viewAsDeviceRule) ?? nil
         reporter = try container.decodeIfPresent(String.self, forKey: .reporter) ?? "xcode"
         disableWhileBuildingForIB = try container.decodeIfPresent(Bool.self, forKey: .disableWhileBuildingForIB) ?? true

--- a/Sources/IBLinterKit/Config/UseTraitCollectionsConfig.swift
+++ b/Sources/IBLinterKit/Config/UseTraitCollectionsConfig.swift
@@ -1,0 +1,25 @@
+//
+//  UseTraitCollectionsConfig.swift
+//  IBLinterKit
+//
+//  Created by Blazej SLEBODA on 13/09/2020
+//
+
+import Foundation
+
+public struct UseTraitCollectionsConfig: Codable {
+    public let useTraitCollections: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case useTraitCollections = "use_trait_collections"
+    }
+
+    init(useTraitCollections: Bool) {
+        self.useTraitCollections = useTraitCollections
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        useTraitCollections = try container.decode(Bool.self, forKey: .useTraitCollections)
+    }
+}

--- a/Sources/IBLinterKit/Config/UseTraitCollectionsConfig.swift
+++ b/Sources/IBLinterKit/Config/UseTraitCollectionsConfig.swift
@@ -8,18 +8,18 @@
 import Foundation
 
 public struct UseTraitCollectionsConfig: Codable {
-    public let useTraitCollections: Bool
+    public let enabled: Bool
 
     enum CodingKeys: String, CodingKey {
-        case useTraitCollections = "use_trait_collections"
+        case enabled
     }
 
-    init(useTraitCollections: Bool) {
-        self.useTraitCollections = useTraitCollections
+    init(enabled: Bool) {
+        self.enabled = enabled
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        useTraitCollections = try container.decode(Bool.self, forKey: .useTraitCollections)
+        enabled = try container.decode(Bool.self, forKey: .enabled)
     }
 }

--- a/Sources/IBLinterKit/Rule.swift
+++ b/Sources/IBLinterKit/Rule.swift
@@ -36,6 +36,7 @@ public struct Rules {
             CustomModuleRule.self,
             UseBaseClassRule.self,
             AmbiguousViewRule.self,
+            UseTraitCollections.self,
             ViewAsDeviceRule.self,
             ReuseIdentifierRule.self,
             ColorResourcesRule.self

--- a/Sources/IBLinterKit/Rules/UseTraitCollections.swift
+++ b/Sources/IBLinterKit/Rules/UseTraitCollections.swift
@@ -1,0 +1,57 @@
+//
+//  UseTraitCollections.swift
+//  IBLinterKit
+//
+//  Created by Blazej SLEBODA on 13/09/2020
+//
+
+import IBDecodable
+
+extension Rules {
+
+    struct UseTraitCollections: Rule {
+
+        static var identifier = "use_trait_collections"
+        static var description = "Check id document useTraitCollections is enabled or diasbled"
+        let useTraitCollections: Bool
+
+        init(context: Context) {
+            if let configUseTraitCollectionRule = context.config.useTraitCollectionsRule {
+                useTraitCollections = configUseTraitCollectionRule.useTraitCollections
+            } else {
+                useTraitCollections = true
+            }
+        }
+
+        func validate(storyboard: StoryboardFile) -> [Violation] {
+            Rules.violation(useTraitCollections, file: storyboard)
+        }
+
+        func validate(xib: XibFile) -> [Violation] {
+            Rules.violation(useTraitCollections, file: xib)
+        }
+
+    }
+
+    fileprivate static func violation<T: InterfaceBuilderFile>(_ useTraitCollection: Bool, file: T) -> [Violation] {
+
+        guard let document = file.document as? InterfaceBuilderDocument else {
+            return []
+        }
+
+        if useTraitCollection {
+            if document.useTraitCollections == .some(true) {
+                return []
+            } else {
+                return [Violation(pathString: file.pathString, message: "useTraitCollection must be enabled", level: .warning)]
+            }
+        } else {
+            if [Bool?(false), .none].contains(document.useTraitCollections) {
+                return []
+            } else {
+                return [Violation(pathString: file.pathString, message: "useTraitCollection must be disabled", level: .warning)]
+            }
+        }
+    }
+
+}

--- a/Sources/IBLinterKit/Rules/UseTraitCollections.swift
+++ b/Sources/IBLinterKit/Rules/UseTraitCollections.swift
@@ -13,33 +13,33 @@ extension Rules {
 
         static var identifier = "use_trait_collections"
         static var description = "Check id document useTraitCollections is enabled or diasbled"
-        let useTraitCollections: Bool
+        let enabled: Bool
 
         init(context: Context) {
             if let configUseTraitCollectionRule = context.config.useTraitCollectionsRule {
-                useTraitCollections = configUseTraitCollectionRule.useTraitCollections
+                enabled = configUseTraitCollectionRule.enabled
             } else {
-                useTraitCollections = true
+                enabled = true
             }
         }
 
         func validate(storyboard: StoryboardFile) -> [Violation] {
-            Rules.violation(useTraitCollections, file: storyboard)
+            Rules.violation(enabled, file: storyboard)
         }
 
         func validate(xib: XibFile) -> [Violation] {
-            Rules.violation(useTraitCollections, file: xib)
+            Rules.violation(enabled, file: xib)
         }
 
     }
 
-    fileprivate static func violation<T: InterfaceBuilderFile>(_ useTraitCollection: Bool, file: T) -> [Violation] {
+    fileprivate static func violation<T: InterfaceBuilderFile>(_ enabled: Bool, file: T) -> [Violation] {
 
         guard let document = file.document as? InterfaceBuilderDocument else {
             return []
         }
 
-        if useTraitCollection {
+        if enabled {
             if document.useTraitCollections == .some(true) {
                 return []
             } else {

--- a/Tests/IBLinterKitTest/Resources/Rules/UseTraitCollectionsRule/UseTraitCollectionsNoTest.storyboard
+++ b/Tests/IBLinterKitTest/Resources/Rules/UseTraitCollectionsRule/UseTraitCollectionsNoTest.storyboard
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_5" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+    </dependencies>
+    <scenes/>
+</document>

--- a/Tests/IBLinterKitTest/Resources/Rules/UseTraitCollectionsRule/UseTraitCollectionsYesTest.storyboard
+++ b/Tests/IBLinterKitTest/Resources/Rules/UseTraitCollectionsRule/UseTraitCollectionsYesTest.storyboard
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_5" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+    </dependencies>
+    <scenes/>
+</document>

--- a/Tests/IBLinterKitTest/Rules/UseTraitCollectionsTests.swift
+++ b/Tests/IBLinterKitTest/Rules/UseTraitCollectionsTests.swift
@@ -13,53 +13,52 @@ class UseTraitCollectionsTests: XCTestCase {
 
     let fixture = Fixture()
     
-    var noUrl: URL!
-    var yesUrl: URL!
+    var storyboardUseTraitCollectionsYes: StoryboardFile!
+    var storyboardUseTraitCollectionsNo: StoryboardFile!
     
     override func setUp() {
         super.setUp()
-        noUrl = fixture.path("Resources/Rules/UseTraitCollectionsRule/UseTraitCollectionsNoTest.storyboard")
-        yesUrl = fixture.path("Resources/Rules/UseTraitCollectionsRule/UseTraitCollectionsYesTest.storyboard")
+        
+        let disabledUrl = fixture.path("Resources/Rules/UseTraitCollectionsRule/UseTraitCollectionsNoTest.storyboard")
+        let enabledUrl = fixture.path("Resources/Rules/UseTraitCollectionsRule/UseTraitCollectionsYesTest.storyboard")
+        
+        storyboardUseTraitCollectionsYes = try! .init(url: enabledUrl)
+        storyboardUseTraitCollectionsNo = try! .init(url: disabledUrl)
+        
     }
     
-    func testUseTraitCollectionsWithEmptyConfig() {
-        let contextMock = Context.mock(from: .default)
-        XCTAssertNil(contextMock.config.useTraitCollectionsRule)
-        XCTAssertFalse(Rules.UseTraitCollections.isDefault)
-    }
-    
-    func testUseTraitCollectionsEnabledWithDefaults() {
-        let defaultContext = Context.mock(from: Config.init(enabledRules: [Rules.UseTraitCollections.identifier]))
-        let ngRule = Rules.UseTraitCollections(context: defaultContext)
-        let ngViolations = try! ngRule.validate(xib: XibFile(url: noUrl))
-        XCTAssertEqual(ngViolations.count, 1)
+    func testUseTraitCollectionsNoConfig() {
+        let ibLinterConfig = Config.default
+        let rule = Rules.UseTraitCollections(context: .mock(from: ibLinterConfig))
         
-        let okConfig = Config(useTraitCollectionsRule: UseTraitCollectionsConfig(useTraitCollections: true))
-        let okRule = Rules.UseTraitCollections(context: .mock(from: okConfig))
-        let okViolations = try! okRule.validate(xib: XibFile(url: yesUrl))
-        XCTAssertTrue(okViolations.isEmpty)
+        let noViolations = rule.validate(storyboard: storyboardUseTraitCollectionsNo)
+        XCTAssertEqual(noViolations.count, 1)
+        
+        let yesViolations = rule.validate(storyboard: storyboardUseTraitCollectionsYes)
+        XCTAssertTrue(yesViolations.isEmpty)
     }
 
-    func testUseTraitCollectionsEnabledWithTrue() {
-        let ngConfig = Config(useTraitCollectionsRule: UseTraitCollectionsConfig(useTraitCollections: true))
-        let ngRule = Rules.UseTraitCollections(context: .mock(from: ngConfig))
-        let ngViolations = try! ngRule.validate(xib: XibFile(url: noUrl))
-        XCTAssertEqual(ngViolations.count, 1)
+    func testUseTraitCollectionsConfigWithTrue() {
+        let useTraitCollectionsConfig = UseTraitCollectionsConfig(useTraitCollections: true)
+        let ibLinterConfig = Config(useTraitCollectionsRule: useTraitCollectionsConfig)
+        let rule = Rules.UseTraitCollections(context: .mock(from: ibLinterConfig))
         
-        let okConfig = Config(useTraitCollectionsRule: UseTraitCollectionsConfig(useTraitCollections: true))
-        let okRule = Rules.UseTraitCollections(context: .mock(from: okConfig))
-        let okViolations = try! okRule.validate(xib: XibFile(url: yesUrl))
-        XCTAssertTrue(okViolations.isEmpty)
+        let noViolations = rule.validate(storyboard: storyboardUseTraitCollectionsNo)
+        XCTAssertEqual(noViolations.count, 1)
+        
+        let yesViolations = rule.validate(storyboard: storyboardUseTraitCollectionsYes)
+        XCTAssertTrue(yesViolations.isEmpty)
     }
 
-    func testUseTraitCollectionsEnabledWithFalse() {
-        let config = Config(useTraitCollectionsRule: .some(.init(useTraitCollections: false)))
-        let ngRule = Rules.UseTraitCollections(context: .mock(from: config))
-        let ngViolations = try! ngRule.validate(xib: XibFile(url: noUrl))
-        XCTAssertTrue(ngViolations.isEmpty)
+    func testUseTraitCollectionsConfigWithFalse() {
+        let useTraitCollectionsConfig = UseTraitCollectionsConfig(useTraitCollections: false)
+        let ibLinterConfig = Config(useTraitCollectionsRule: useTraitCollectionsConfig)
+        let rule = Rules.UseTraitCollections(context: .mock(from: ibLinterConfig))
         
-        let okRule = Rules.UseTraitCollections(context: .mock(from: config))
-        let okViolations = try! okRule.validate(xib: XibFile(url: yesUrl))
-        XCTAssertEqual(okViolations.count, 1)
+        let noViolations = rule.validate(storyboard: storyboardUseTraitCollectionsNo)
+        XCTAssertTrue(noViolations.isEmpty)
+        
+        let yesViolations = rule.validate(storyboard: storyboardUseTraitCollectionsYes)
+        XCTAssertEqual(yesViolations.count, 1)
     }
 }

--- a/Tests/IBLinterKitTest/Rules/UseTraitCollectionsTests.swift
+++ b/Tests/IBLinterKitTest/Rules/UseTraitCollectionsTests.swift
@@ -1,0 +1,65 @@
+//
+//  UseTraitCollectionsTests.swift
+//  IBLinterKitTest
+//
+//  Created by Blazej SLEBODA on 13/09/2020
+//
+
+@testable import IBLinterKit
+import XCTest
+import IBDecodable
+
+class UseTraitCollectionsTests: XCTestCase {
+
+    let fixture = Fixture()
+    
+    var noUrl: URL!
+    var yesUrl: URL!
+    
+    override func setUp() {
+        super.setUp()
+        noUrl = fixture.path("Resources/Rules/UseTraitCollectionsRule/UseTraitCollectionsNoTest.storyboard")
+        yesUrl = fixture.path("Resources/Rules/UseTraitCollectionsRule/UseTraitCollectionsYesTest.storyboard")
+    }
+    
+    func testUseTraitCollectionsWithEmptyConfig() {
+        let contextMock = Context.mock(from: .default)
+        XCTAssertNil(contextMock.config.useTraitCollectionsRule)
+        XCTAssertFalse(Rules.UseTraitCollections.isDefault)
+    }
+    
+    func testUseTraitCollectionsEnabledWithDefaults() {
+        let defaultContext = Context.mock(from: Config.init(enabledRules: [Rules.UseTraitCollections.identifier]))
+        let ngRule = Rules.UseTraitCollections(context: defaultContext)
+        let ngViolations = try! ngRule.validate(xib: XibFile(url: noUrl))
+        XCTAssertEqual(ngViolations.count, 1)
+        
+        let okConfig = Config(useTraitCollectionsRule: UseTraitCollectionsConfig(useTraitCollections: true))
+        let okRule = Rules.UseTraitCollections(context: .mock(from: okConfig))
+        let okViolations = try! okRule.validate(xib: XibFile(url: yesUrl))
+        XCTAssertTrue(okViolations.isEmpty)
+    }
+
+    func testUseTraitCollectionsEnabledWithTrue() {
+        let ngConfig = Config(useTraitCollectionsRule: UseTraitCollectionsConfig(useTraitCollections: true))
+        let ngRule = Rules.UseTraitCollections(context: .mock(from: ngConfig))
+        let ngViolations = try! ngRule.validate(xib: XibFile(url: noUrl))
+        XCTAssertEqual(ngViolations.count, 1)
+        
+        let okConfig = Config(useTraitCollectionsRule: UseTraitCollectionsConfig(useTraitCollections: true))
+        let okRule = Rules.UseTraitCollections(context: .mock(from: okConfig))
+        let okViolations = try! okRule.validate(xib: XibFile(url: yesUrl))
+        XCTAssertTrue(okViolations.isEmpty)
+    }
+
+    func testUseTraitCollectionsEnabledWithFalse() {
+        let config = Config(useTraitCollectionsRule: .some(.init(useTraitCollections: false)))
+        let ngRule = Rules.UseTraitCollections(context: .mock(from: config))
+        let ngViolations = try! ngRule.validate(xib: XibFile(url: noUrl))
+        XCTAssertTrue(ngViolations.isEmpty)
+        
+        let okRule = Rules.UseTraitCollections(context: .mock(from: config))
+        let okViolations = try! okRule.validate(xib: XibFile(url: yesUrl))
+        XCTAssertEqual(okViolations.count, 1)
+    }
+}

--- a/Tests/IBLinterKitTest/Rules/UseTraitCollectionsTests.swift
+++ b/Tests/IBLinterKitTest/Rules/UseTraitCollectionsTests.swift
@@ -39,7 +39,7 @@ class UseTraitCollectionsTests: XCTestCase {
     }
 
     func testUseTraitCollectionsConfigWithTrue() {
-        let useTraitCollectionsConfig = UseTraitCollectionsConfig(useTraitCollections: true)
+        let useTraitCollectionsConfig = UseTraitCollectionsConfig(enabled: true)
         let ibLinterConfig = Config(useTraitCollectionsRule: useTraitCollectionsConfig)
         let rule = Rules.UseTraitCollections(context: .mock(from: ibLinterConfig))
         
@@ -51,7 +51,7 @@ class UseTraitCollectionsTests: XCTestCase {
     }
 
     func testUseTraitCollectionsConfigWithFalse() {
-        let useTraitCollectionsConfig = UseTraitCollectionsConfig(useTraitCollections: false)
+        let useTraitCollectionsConfig = UseTraitCollectionsConfig(enabled: false)
         let ibLinterConfig = Config(useTraitCollectionsRule: useTraitCollectionsConfig)
         let rule = Rules.UseTraitCollections(context: .mock(from: ibLinterConfig))
         


### PR DESCRIPTION
UseTraitCollections rule is useful when developing a 100% iPhone or iPad app and working with Interface Builder to check scenes under different devices.

UseTaitCollections property of a storyboard enable / disable iPhone or iPad devices from Interface Builder device selector and makes the list of available devices shorter and easier to navigate.

**List of devices for a default Xcode iOS project (UseTraitCollection is enabled):**

![Capture d’écran 2020-09-21 à 09 11 19](https://user-images.githubusercontent.com/5544365/93740406-b244e500-fbea-11ea-8303-5a8313d9750d.png)

**Disable Trait Variations and keep size class for iPhone only**

![Capture d’écran 2020-09-21 à 09 11 26](https://user-images.githubusercontent.com/5544365/93740508-e7513780-fbea-11ea-9a30-cdc0ed73206a.png)

**List of devices for a default Xcode iOS project (UseTraitCollection is disabled):**
![Capture d’écran 2020-09-21 à 09 11 32](https://user-images.githubusercontent.com/5544365/93740526-f3d59000-fbea-11ea-8472-e527eb8ba7b3.png)

