### PR TITLE
Add stackview_backgroundcolor rule

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -67,7 +67,7 @@ Check that Storyboard ID same as ViewController class name.
 |:---------------:|:---------------:|
 |   Default Rule  |  `false` |
 
-Force to background color of stackview should be default.
+Force background color of stackview to be default.
 
 
 ## ImageResourcesRule
@@ -131,4 +131,3 @@ Check that ReuseIdentifier same as class name.
 |   Default Rule  |  `false` |
 
 Check if named color resources are valid.
-

--- a/Rules.md
+++ b/Rules.md
@@ -61,6 +61,15 @@ Display warning when elements use same id.
 Check that Storyboard ID same as ViewController class name.
 
 
+## StackViewBackgroundColorRule
+
+|    identifier   | `stackview_backgroundcolor` |
+|:---------------:|:---------------:|
+|   Default Rule  |  `false` |
+
+Force to background color of stackview should be default.
+
+
 ## ImageResourcesRule
 
 |    identifier   | `image_resources` |

--- a/Sources/IBLinterKit/Rule.swift
+++ b/Sources/IBLinterKit/Rule.swift
@@ -31,6 +31,7 @@ public struct Rules {
             DuplicateConstraintRule.self,
             DuplicateIDRule.self,
             StoryboardViewControllerId.self,
+            StackViewBackgroundColorRule.self,
             ImageResourcesRule.self,
             CustomModuleRule.self,
             UseBaseClassRule.self,

--- a/Sources/IBLinterKit/Rules/ReuseIdentifierRule.swift
+++ b/Sources/IBLinterKit/Rules/ReuseIdentifierRule.swift
@@ -5,7 +5,7 @@ extension Rules {
     struct ReuseIdentifierRule: Rule {
 
         static let identifier = "reuse_identifier"
-        static let description = " Check that ReuseIdentifier same as class name."
+        static let description = "Check that ReuseIdentifier same as class name."
 
         init(context: Context) {}
 

--- a/Sources/IBLinterKit/Rules/StackViewBackgroundColorRule.swift
+++ b/Sources/IBLinterKit/Rules/StackViewBackgroundColorRule.swift
@@ -1,0 +1,36 @@
+import Foundation
+import IBDecodable
+
+extension Rules {
+
+    struct StackViewBackgroundColorRule: Rule {
+
+        static let identifier = "stackview_backgroundcolor"
+        static let description = "Force to background color of stackview should be default."
+
+        public init(context: Context) {}
+
+        func validate(storyboard: StoryboardFile) -> [Violation] {
+            guard let scenes = storyboard.document.scenes else { return [] }
+            let views = scenes.compactMap { $0.viewController?.viewController.rootView }
+            return views.flatMap { validate(for: $0, file: storyboard) }
+        }
+
+        func validate(xib: XibFile) -> [Violation] {
+            guard let views = xib.document.views else { return [] }
+            return views.flatMap { validate(for: $0.view, file: xib) }
+        }
+
+        private func validate<T: InterfaceBuilderFile>(for view: ViewProtocol, file: T) -> [Violation] {
+            let violations: [Violation] = {
+                guard let stackView = view as? StackView, stackView.backgroundColor != nil else {
+                    return []
+                }
+                let message = "\(viewName(of: view)) should not have background color"
+                return [Violation(pathString: file.pathString, message: message, level: .warning)]
+            }()
+
+            return violations + (view.subviews?.flatMap { validate(for: $0.view, file: file) } ?? [])
+        }
+    }
+}

--- a/Sources/IBLinterKit/Rules/StackViewBackgroundColorRule.swift
+++ b/Sources/IBLinterKit/Rules/StackViewBackgroundColorRule.swift
@@ -6,7 +6,7 @@ extension Rules {
     struct StackViewBackgroundColorRule: Rule {
 
         static let identifier = "stackview_backgroundcolor"
-        static let description = "Force to background color of stackview should be default."
+        static let description = "Force background color of StackView to be default."
 
         public init(context: Context) {}
 

--- a/Tests/IBLinterKitTest/Resources/Rules/StackViewBackgroundColorRule/StackViewBackgroundColorRule.storyboard
+++ b/Tests/IBLinterKitTest/Resources/Rules/StackViewBackgroundColorRule/StackViewBackgroundColorRule.storyboard
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="Ksh-iO-HZ6">
+            <objects>
+                <viewController id="wzJ-Fq-ORC" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="die-K4-xTx">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ScP-yv-bu5">
+                                <rect key="frame" x="87" y="278" width="200" height="110"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="5xa-Hd-vz7"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="J7y-4J-g9J" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1295.2" y="-122.78860569715144"/>
+        </scene>
+    </scenes>
+</document>

--- a/Tests/IBLinterKitTest/Resources/Rules/StackViewBackgroundColorRule/StackViewBackgroundColorRule.xib
+++ b/Tests/IBLinterKitTest/Resources/Rules/StackViewBackgroundColorRule/StackViewBackgroundColorRule.xib
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="Agb-ke-kHh">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fpa-Pi-xNX">
+                    <rect key="frame" x="132" y="233" width="110" height="200"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" systemColor="systemGray2Color" red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="F5J-Eb-YtQ"/>
+            <point key="canvasLocation" x="128" y="-95"/>
+        </view>
+        <stackView opaque="NO" contentMode="scaleToFill" id="7k5-gw-fgE">
+            <rect key="frame" x="0.0" y="0.0" width="200" height="110"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <color key="backgroundColor" systemColor="systemOrangeColor" red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <viewLayoutGuide key="safeArea" id="j4r-FQ-mUo"/>
+            <point key="canvasLocation" x="713" y="-138"/>
+        </stackView>
+    </objects>
+</document>

--- a/Tests/IBLinterKitTest/Rules/StackViewBackgroundColorRuleTests.swift
+++ b/Tests/IBLinterKitTest/Rules/StackViewBackgroundColorRuleTests.swift
@@ -1,0 +1,22 @@
+@testable import IBLinterKit
+import XCTest
+import IBDecodable
+
+class StackViewBackgroundColorRuleTests: XCTestCase {
+
+    let fixture = Fixture()
+
+    func testStackViewBackgroundColorStoryboard() {
+        let url = fixture.path("Resources/Rules/StackViewBackgroundColorRule/StackViewBackgroundColorRule.storyboard")
+        let rule = Rules.StackViewBackgroundColorRule(context: .mock(from: .default))
+        let violations = try! rule.validate(storyboard: StoryboardFile(url: url))
+        XCTAssertEqual(violations.count, 1)
+    }
+
+    func testStackViewBackgroundColorXib() {
+        let url = fixture.path("Resources/Rules/StackViewBackgroundColorRule/StackViewBackgroundColorRule.xib")
+        let rule = Rules.StackViewBackgroundColorRule(context: .mock(from: .default))
+        let violations = try! rule.validate(xib: XibFile(url: url))
+        XCTAssertEqual(violations.count, 2)
+    }
+}


### PR DESCRIPTION
Hi @kateinoigakukun and @phimage 

Since iOS 14, UIStackView backing layer is changed from `CATransformLayer` to `CALayer` that means draw something.

This rule detect background color definition of UIStackView to check background color look compatibility between iOS 9-13 and iOS 14.

reference: https://useyourloaf.com/blog/stack-view-background-color-in-ios-14/