### PR TITLE
Add support for filename as lint target

### DIFF
--- a/Sources/IBLinterKit/Validator.swift
+++ b/Sources/IBLinterKit/Validator.swift
@@ -91,24 +91,31 @@ public class Validator {
                     let files = self.interfaceBuilderFiles(atPath: URL(fileURLWithPath: path))
                     result.xibPaths.formUnion(files.xibPaths)
                     result.storyboardPaths.formUnion(files.storyboardPaths)
-            }
+                }
         }
 
         func interfaceBuilderFiles(atPath path: URL) -> InterfaceBuilderFiles {
             var xibs: Set<URL> = []
             var storyboards: Set<URL> = []
+            guard path.hasDirectoryPath else {
+                switch path.pathExtension {
+                case "xib": xibs.insert(path)
+                case "storyboard": storyboards.insert(path)
+                default: break
+                }
+                return InterfaceBuilderFiles(xibPaths: xibs, storyboardPaths: storyboards)
+            }
             guard let enumerator = fileManager.enumerator(at: path, includingPropertiesForKeys: [.isRegularFileKey]) else {
                 return InterfaceBuilderFiles(xibPaths: xibs, storyboardPaths: storyboards)
             }
-
-            for element in enumerator {
-                guard let absolute = element as? URL else { continue }
-                switch absolute.pathExtension {
-                case "xib": xibs.insert(absolute)
-                case "storyboard": storyboards.insert(absolute)
-                default: continue
+            enumerator.compactMap { $0 as? URL }
+                .forEach { url in
+                    switch url.pathExtension {
+                    case "xib": xibs.insert(url)
+                    case "storyboard": storyboards.insert(url)
+                    default: break
+                    }
                 }
-            }
             return InterfaceBuilderFiles(xibPaths: xibs, storyboardPaths: storyboards)
         }
     }

--- a/Tests/IBLinterKitTest/Utils/LintablePathsTests.swift
+++ b/Tests/IBLinterKitTest/Utils/LintablePathsTests.swift
@@ -6,7 +6,7 @@ class LintablePathsTests: XCTestCase {
 
     let fixture = Fixture()
 
-    func testIncluded() {
+    func testExcludedDirectory() {
         let config = Config(
             disabledRules: [], enabledRules: [],
             excluded: ["Level1_1"], included: [],
@@ -22,7 +22,25 @@ class LintablePathsTests: XCTestCase {
         )
     }
 
-    func testExcluded() {
+    func testExcludedFile() {
+        let config = Config(
+            disabledRules: [], enabledRules: [],
+            excluded: ["Level1_2/Level1_2.xib"], included: [],
+            customModuleRule: [], baseClassRule: [], reporter: ""
+        )
+        let validator = Validator(externalRules: [])
+        let projectPath = fixture.path("Resources/Utils/Glob/ProjectMock")
+        let lintablePaths = validator.lintablePaths(workDirectory: projectPath, config: config).xib
+
+        XCTAssertEqual(
+            lintablePaths.map { $0.path }.sorted(),
+            [projectPath.appendingPathComponent("Level1_1/Level1_1.xib").path,
+             projectPath.appendingPathComponent("Level1_1/Level2_1/Level2_1.xib").path,
+             projectPath.appendingPathComponent("Level1_1/Level2_2/Level2_2.xib").path]
+        )
+    }
+
+    func testIncludedDirectort() {
         let config = Config(
             disabledRules: [], enabledRules: [],
             excluded: [], included: ["Level1_2"],
@@ -37,6 +55,22 @@ class LintablePathsTests: XCTestCase {
             [projectPath.appendingPathComponent("Level1_2/Level1_2.xib").path]
         )
     }
+
+    func testIncludedFile() {
+        let config = Config(
+            disabledRules: [], enabledRules: [],
+            excluded: [], included: ["Level1_1/Level2_1/Level2_1.xib"],
+            customModuleRule: [], baseClassRule: [], reporter: ""
+        )
+        let validator = Validator(externalRules: [])
+        let projectPath = fixture.path("Resources/Utils/Glob/ProjectMock")
+        let lintablePaths = validator.lintablePaths(workDirectory: projectPath, config: config).xib
+
+        XCTAssertEqual(
+            lintablePaths.map { $0.path },
+            [projectPath.appendingPathComponent("Level1_1/Level2_1/Level2_1.xib").path]
+        )
+    }   
 
     func testIncludedAndExcluded() {
         let config = Config(


### PR DESCRIPTION
The file name is now also supported, since specifying a non-directory in the exclusion setting was not reflected.

For example, a specification like the following
```
excluded:
  - App/interfacebulder.storyboard
```