### PR TITLE
Add has initial view controller and has single view controller rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ enabled_rules:
   - use_trait_collections
   - hides_bottom_bar
   - has_single_view_controller
+  - has_initial_view_controller
 disabled_rules:
   - custom_class_name
 excluded:

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ enabled_rules:
   - relative_to_margin
   - use_trait_collections
   - hides_bottom_bar
+  - has_single_view_controller
 disabled_rules:
   - custom_class_name
 excluded:

--- a/Sources/IBLinterKit/Rule.swift
+++ b/Sources/IBLinterKit/Rule.swift
@@ -41,6 +41,7 @@ public struct Rules {
             ReuseIdentifierRule.self,
             ColorResourcesRule.self,
             HidesBottomBarRule.self,
+            HasInitialViewControllerRule.self,
             HasSingleViewControllerRule.self
         ]
     }()

--- a/Sources/IBLinterKit/Rule.swift
+++ b/Sources/IBLinterKit/Rule.swift
@@ -40,7 +40,8 @@ public struct Rules {
             ViewAsDeviceRule.self,
             ReuseIdentifierRule.self,
             ColorResourcesRule.self,
-            HidesBottomBarRule.self
+            HidesBottomBarRule.self,
+            HasSingleViewControllerRule.self
         ]
     }()
 

--- a/Sources/IBLinterKit/Rules/HasInitialViewControllerRule.swift
+++ b/Sources/IBLinterKit/Rules/HasInitialViewControllerRule.swift
@@ -1,0 +1,35 @@
+//
+//  HasInitialViewControllerRule.swift
+//  IBLinterKit
+//
+//  Created by Blazej SLEBODA on 24/03/2022
+//
+
+import IBDecodable
+
+extension Rules {
+
+    struct HasInitialViewControllerRule: Rule {
+
+        static var identifier = "has_initial_view_controller"
+        static var description = "Checks if a storyboard has an initial view controller"
+
+        init(context: Context) { }
+
+        func validate(storyboard: StoryboardFile) -> [Violation] {
+            Rules.violation(file: storyboard)
+        }
+
+        func validate(xib: XibFile) -> [Violation] { [] }
+
+    }
+
+    fileprivate static func violation(file: StoryboardFile) -> [Violation] {
+        if file.document.initialViewController == nil {
+            return [Violation(pathString: file.pathString, message: "The storyboard must have an initial view controller", level: .warning)]
+        } else {
+            return []
+        }
+    }
+
+}

--- a/Sources/IBLinterKit/Rules/HasSingleViewControllerRule.swift
+++ b/Sources/IBLinterKit/Rules/HasSingleViewControllerRule.swift
@@ -1,0 +1,37 @@
+//
+//  HasSingleViewControllerRule.swift
+//  IBLinterKit
+//
+//  Created by Blazej SLEBODA on 24/03/2022
+//
+
+import IBDecodable
+
+extension Rules {
+
+    struct HasSingleViewControllerRule: Rule {
+
+        static var identifier = "has_single_view_controller"
+        static var description = "Checks if a storyboard has a single view controller, references are allowed"
+
+        init(context: Context) { }
+
+        func validate(storyboard: StoryboardFile) -> [Violation] {
+            Rules.violation(file: storyboard)
+        }
+
+        func validate(xib: XibFile) -> [Violation] { [] }
+
+    }
+
+    fileprivate static func violation(file: StoryboardFile) -> [Violation] {
+        let numberOfViewControllersInStoryboard = file.document.scenes?.filter { $0.viewController != nil }.count ?? 0
+
+        if numberOfViewControllersInStoryboard > 1 {
+            return [Violation(pathString: file.pathString, message: "Should have only a single VC", level: .warning)]
+        } else {
+            return []
+        }
+    }
+
+}

--- a/Tests/IBLinterKitTest/Resources/Rules/HasInitialViewController/HasInitialViewControllerBad.storyboard
+++ b/Tests/IBLinterKitTest/Resources/Rules/HasInitialViewController/HasInitialViewControllerBad.storyboard
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="261" y="116"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Tests/IBLinterKitTest/Resources/Rules/HasInitialViewController/HasInitialViewControllerGood.storyboard
+++ b/Tests/IBLinterKitTest/Resources/Rules/HasInitialViewController/HasInitialViewControllerGood.storyboard
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="207" y="77"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Tests/IBLinterKitTest/Resources/Rules/HasSingleViewController/HasSingleViewControllerBadTwoController.storyboard
+++ b/Tests/IBLinterKitTest/Resources/Rules/HasSingleViewController/HasSingleViewControllerBadTwoController.storyboard
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="74" y="50"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="iuW-WR-o8S">
+            <objects>
+                <viewController id="wuB-bf-dCf" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="FTL-oA-ByO">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="x34-Zy-wV2"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Hx1-BG-EdN" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="817" y="59"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Tests/IBLinterKitTest/Resources/Rules/HasSingleViewController/HasSingleViewControllerGood.storyboard
+++ b/Tests/IBLinterKitTest/Resources/Rules/HasSingleViewController/HasSingleViewControllerGood.storyboard
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="74" y="50"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Tests/IBLinterKitTest/Resources/Rules/HasSingleViewController/HasSingleViewControllerGoodSingleSceneWithReference.storyboard
+++ b/Tests/IBLinterKitTest/Resources/Rules/HasSingleViewController/HasSingleViewControllerGoodSingleSceneWithReference.storyboard
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="74" y="50"/>
+        </scene>
+        <!--Storyboard Reference-->
+        <scene sceneID="d8Y-JV-ud2">
+            <objects>
+                <viewControllerPlaceholder id="xf4-D7-IQw" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="qKs-3L-hxf" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="630" y="113"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Tests/IBLinterKitTest/Rules/HasInitialViewControllerTests.swift
+++ b/Tests/IBLinterKitTest/Rules/HasInitialViewControllerTests.swift
@@ -1,0 +1,44 @@
+//
+//  HasInitialViewController.swift
+//  IBLinterKitTest
+//
+//  Created by Blazej SLEBODA on 24/03/2022
+//
+
+@testable import IBLinterKit
+import XCTest
+import IBDecodable
+
+class HasInitialViewControllerTests: XCTestCase {
+
+    let fixture = Fixture()
+    
+    private var storyboardGood: StoryboardFile!
+    private var storyboardBad: StoryboardFile!
+    
+    override func setUp() {
+        super.setUp()
+        
+        let pathToStoryboardGood = fixture.path("Resources/Rules/HasInitialViewController/HasInitialViewControllerGood.storyboard")
+        storyboardGood = try! .init(url: pathToStoryboardGood)
+        
+        let pathToStoryboardBad = fixture.path("Resources/Rules/HasInitialViewController/HasInitialViewControllerBad.storyboard")
+        storyboardBad = try! .init(url: pathToStoryboardBad)
+    }
+    
+    func testHasInitialViewControllerInGoodStoryboard() {
+        let rule = createRule()
+        let warnings = rule.validate(storyboard: storyboardGood)
+        XCTAssertTrue(warnings.isEmpty)
+    }
+
+    func testHasInitialViewControllerInBadStoryboard() {
+        let rule = createRule()
+        let warnings = rule.validate(storyboard: storyboardBad)
+        XCTAssertEqual(warnings.count, 1)
+    }
+    
+    private func createRule() -> Rule {
+        Rules.HasInitialViewControllerRule(context: .mock(from: .init()))
+    }
+}

--- a/Tests/IBLinterKitTest/Rules/HasSingleViewControllerTests.swift
+++ b/Tests/IBLinterKitTest/Rules/HasSingleViewControllerTests.swift
@@ -1,0 +1,55 @@
+//
+//  HasSingleViewControllerTests.swift
+//  IBLinterKitTest
+//
+//  Created by Blazej SLEBODA on 24/03/2022
+//
+
+@testable import IBLinterKit
+import XCTest
+import IBDecodable
+
+class HasSingleViewControllerTests: XCTestCase {
+
+    let fixture = Fixture()
+    
+    private var storyboardGood: StoryboardFile!
+    private var storyboardGoodSingleSceneWithReference: StoryboardFile!
+    private var storyboardBadTwoController: StoryboardFile!
+    
+    
+    override func setUp() {
+        super.setUp()
+        
+        let pathToStoryboardGood = fixture.path("Resources/Rules/HasSingleViewController/HasSingleViewControllerGood.storyboard")
+        storyboardGood = try! .init(url: pathToStoryboardGood)
+        
+        let pathToStoryboardGoodSingleSceneWithReference = fixture.path("Resources/Rules/HasSingleViewController/HasSingleViewControllerGoodSingleSceneWithReference.storyboard")
+        storyboardGoodSingleSceneWithReference = try! .init(url: pathToStoryboardGoodSingleSceneWithReference)
+        
+        let pathToStoryboardBadTwoController = fixture.path("Resources/Rules/HasSingleViewController/HasSingleViewControllerBadTwoController.storyboard")
+        storyboardBadTwoController = try! .init(url: pathToStoryboardBadTwoController)
+    }
+    
+    func testHasSingleViewControllerInGoodStoryboard() {
+        let rule = createRule()
+        let warnings = rule.validate(storyboard: storyboardGood)
+        XCTAssertTrue(warnings.isEmpty)
+    }
+
+    func testHasSingleViewControllerInGoodSingleSceneWithReference() {
+        let rule = createRule()
+        let warnings = rule.validate(storyboard: storyboardGoodSingleSceneWithReference)
+        XCTAssertTrue(warnings.isEmpty)
+    }
+
+    func testHasSingleViewControllerInBad() {
+        let rule = createRule()
+        let warnings = rule.validate(storyboard: storyboardBadTwoController)
+        XCTAssertFalse(warnings.isEmpty)
+    }
+    
+    private func createRule() -> Rule {
+        Rules.HasSingleViewControllerRule(context: .mock(from: .init()))
+    }
+}


### PR DESCRIPTION
This PR adds two rules.

**Rule "has_initial_view_controller":**

Checks if "initial view controller" has been selected in the storyboard file. This rule applies to storyboards only.

**Rule "has_single_view_controller":**

Checks if there is only one "view controller" in the "storyboard" files. View controller references don't count as a view controller.
This rule applies to storyboards only.