### PR TITLE
Disable trailing_comma on allRules collection

### DIFF
--- a/.iblinter.yml
+++ b/.iblinter.yml
@@ -1,2 +1,4 @@
 enabled_rules:
   - ambiguous
+disabled_rules:
+  - trailing_comma

--- a/.iblinter.yml
+++ b/.iblinter.yml
@@ -1,4 +1,2 @@
 enabled_rules:
   - ambiguous
-disabled_rules:
-  - trailing_comma

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,3 +12,4 @@ disabled_rules:
   - cyclomatic_complexity
   - pattern_matching_keywords
   - nesting
+  - trailing_comma

--- a/Sources/IBLinterKit/Rule.swift
+++ b/Sources/IBLinterKit/Rule.swift
@@ -42,7 +42,7 @@ public struct Rules {
             ColorResourcesRule.self,
             HidesBottomBarRule.self,
             HasInitialViewControllerRule.self,
-            HasSingleViewControllerRule.self
+            HasSingleViewControllerRule.self,
         ]
     }()
 


### PR DESCRIPTION
Disabling The Swiftlint rule "Trailing Comma Rule" on code level "Rule.swift:24" will simplify the source diff in a code review (one added line instead of one removed line and two added lines) and will mark the "allRules" collection as a collection open for new elements.
I would use the comma where you know you're going to add elements later, and omit it if the list of items is final.

Closes #182 