### PR TITLE
Add custom_view rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ enabled_rules:
   - hides_bottom_bar
   - has_single_view_controller
   - has_initial_view_controller
+  - custom_view
 disabled_rules:
   - custom_class_name
 excluded:

--- a/Sources/IBLinterKit/Rule.swift
+++ b/Sources/IBLinterKit/Rule.swift
@@ -43,6 +43,7 @@ public struct Rules {
             HidesBottomBarRule.self,
             HasInitialViewControllerRule.self,
             HasSingleViewControllerRule.self,
+            CustomViewRule.self,
         ]
     }()
 

--- a/Sources/IBLinterKit/Rules/CustomViewRule.swift
+++ b/Sources/IBLinterKit/Rules/CustomViewRule.swift
@@ -1,0 +1,33 @@
+//
+//  CustomViewRule.swift
+//  
+//
+//  Created by Blazej Sleboda on 07/07/2022.
+//
+
+import Foundation
+import IBDecodable
+import SourceKittenFramework
+
+extension Rules {
+    struct CustomViewRule: Rule {
+
+        static var identifier = "custom_view"
+        static var description = "Emits warnings if storyboard scenes contain custom views"
+
+        init(context: Context) { }
+
+        func validate(storyboard: StoryboardFile) -> [Violation] {
+            guard let scenes = storyboard.document.scenes else { return [] }
+            return scenes.map { scene in
+                scene.customViews?.map { anyView in
+                    let viewId = (anyView as? IBIdentifiable)?.id ?? "non identifiable"
+                    return Violation(pathString: storyboard.pathString, message: "Custom view is not allowed (\(viewId) of Scene: \(scene.id)", level: .warning)
+                } ?? [Violation]()
+            }.flatMap { $0 }
+        }
+
+        func validate(xib: XibFile) -> [Violation] { [] }
+
+    }
+}

--- a/Tests/IBLinterKitTest/Resources/Rules/CustomViewRule/WithCustomViews.storyboard
+++ b/Tests/IBLinterKitTest/Resources/Rules/CustomViewRule/WithCustomViews.storyboard
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="pocTest" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+                <view contentMode="scaleToFill" id="Irg-9b-SDW">
+                    <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <viewLayoutGuide key="safeArea" id="7kl-sj-3ag"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </view>
+            </objects>
+            <point key="canvasLocation" x="-707" y="98"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="Rrx-Kn-yGG">
+            <objects>
+                <viewController id="ML6-xg-k4W" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="1jV-Ih-XYw">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="p99-jB-8xm"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="s1n-Up-Eu0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <visualEffectView opaque="NO" contentMode="scaleToFill" id="m2I-Zk-oPG">
+                    <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="l8Q-T2-XRq">
+                        <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    </view>
+                    <blurEffect style="regular"/>
+                </visualEffectView>
+                <view contentMode="scaleToFill" id="PqB-k7-r16">
+                    <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <viewLayoutGuide key="safeArea" id="Q1P-oJ-JT2"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </view>
+            </objects>
+            <point key="canvasLocation" x="104" y="98"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Tests/IBLinterKitTest/Resources/Rules/CustomViewRule/WithoutCustomViews.storyboard
+++ b/Tests/IBLinterKitTest/Resources/Rules/CustomViewRule/WithoutCustomViews.storyboard
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="pocTest" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-707" y="98"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="Rrx-Kn-yGG">
+            <objects>
+                <viewController id="ML6-xg-k4W" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="1jV-Ih-XYw">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="p99-jB-8xm"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="s1n-Up-Eu0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="104" y="98"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Tests/IBLinterKitTest/Rules/CustomViewTests.swift
+++ b/Tests/IBLinterKitTest/Rules/CustomViewTests.swift
@@ -1,0 +1,34 @@
+//
+//  CustomViewTests.swift
+//  IBLinterKitTest
+//
+//  Created by Blazej Sleboda on 07/07/2022.
+//
+
+@testable import IBLinterKit
+import XCTest
+import IBDecodable
+
+class CustomViewTests: XCTestCase {
+
+    private let fixture = Fixture()
+    private let projectMockPath = "Resources/Rules/CustomViewRule"
+    private var rule: Rules.CustomViewRule!
+
+    override func setUp() {
+        super.setUp()
+        rule = Rules.CustomViewRule(context: .mock(from: .init()))
+    }
+
+    func testStoryboardWithoutCustomObjects() throws {
+        let url = fixture.path("\(projectMockPath)/WithoutCustomViews.storyboard")
+        let violations = try rule.validate(storyboard: StoryboardFile(url: url))
+        XCTAssertTrue(violations.isEmpty)
+    }
+
+    func testStoryboardWithTwoViewControllersInEachOfThemOneCustomObject() throws {
+        let url = fixture.path("\(projectMockPath)/WithCustomViews.storyboard")
+        let violations = try rule.validate(storyboard: StoryboardFile(url: url))
+        XCTAssertEqual(violations.count, 3)
+    }
+}


### PR DESCRIPTION
Add rule "custom_view" which emits warnings if storyboard scenes contain custom views. This rule applies to storyboards only. Use it to restrict the creation of custom view in code, such as tableViewHeaders, later used views etc.