### PR TITLE
Add `--cache-path` option

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "swift-crypto",
+        "repositoryURL": "https://github.com/apple/swift-crypto.git",
+        "state": {
+          "branch": null,
+          "revision": "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
+          "version": "1.1.7"
+        }
+      },
+      {
         "package": "SWXMLHash",
         "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
         "state": {

--- a/Sources/IBLinterFrontend/Commands/ValidateCommand.swift
+++ b/Sources/IBLinterFrontend/Commands/ValidateCommand.swift
@@ -19,6 +19,8 @@ struct ValidateCommand: ParsableCommand {
     var reporter: String?
     @Option(name: .long, help: "the path to IBLint's configuration file", completion: .file())
     var configurationFile: String?
+    @Option(name: .long, help: "the directory of the cache used when linting", completion: .directory)
+    var cachePath: String?
     @Argument(help: "included files/paths to lint. This is ignored if you specified included paths in your yml configuration file.",
               completion: .file())
     var included: [String] = []
@@ -37,6 +39,9 @@ struct ValidateCommand: ParsableCommand {
         }
         if config.included.isEmpty {
             config.included = included
+        }
+        if let cachePath = cachePath {
+            config.cachePath = cachePath
         }
         let validator = Validator()
         let violations = validator.validate(workDirectory: workDirectory, config: config)

--- a/Sources/IBLinterKit/Config/Config.swift
+++ b/Sources/IBLinterKit/Config/Config.swift
@@ -21,6 +21,7 @@ public struct Config: Codable {
     public let reporter: String
     public let disableWhileBuildingForIB: Bool
     public let ignoreCache: Bool
+    public var cachePath: String?
 
     enum CodingKeys: String, CodingKey {
         case disabledRules = "disabled_rules"
@@ -35,6 +36,7 @@ public struct Config: Codable {
         case reporter = "reporter"
         case disableWhileBuildingForIB = "disable_while_building_for_ib"
         case ignoreCache = "ignore_cache"
+        case cachePath = "cache_path"
     }
 
     public static let fileName = ".iblinter.yml"
@@ -53,6 +55,7 @@ public struct Config: Codable {
         reporter = "xcode"
         disableWhileBuildingForIB = true
         ignoreCache = false
+        cachePath = nil
     }
 
     init(disabledRules: [String] = [], enabledRules: [String] = [],
@@ -63,7 +66,7 @@ public struct Config: Codable {
          useTraitCollectionsRule: UseTraitCollectionsConfig? = nil,
          hidesBottomBarRule: HidesBottomBarConfig? = nil,
          reporter: String = "xcode", disableWhileBuildingForIB: Bool = true,
-         ignoreCache: Bool = false) {
+         ignoreCache: Bool = false, cachePath: String? = nil) {
         self.disabledRules = disabledRules
         self.enabledRules = enabledRules
         self.excluded = excluded
@@ -76,6 +79,7 @@ public struct Config: Codable {
         self.reporter = reporter
         self.disableWhileBuildingForIB = disableWhileBuildingForIB
         self.ignoreCache = ignoreCache
+        self.cachePath = cachePath
     }
 
     public init(from decoder: Decoder) throws {

--- a/Sources/IBLinterKit/Utils/Glob.swift
+++ b/Sources/IBLinterKit/Utils/Glob.swift
@@ -42,17 +42,15 @@ public final class Glob {
         let patterns = expandRecursiveStars(pattern: pattern)
         var results: [String] = []
 
-        for pattern in patterns {
-            if executeGlob(pattern: pattern, gt: &gt) {
-                #if os(Linux)
-                let matchCount = Int(gt.gl_pathc)
-                #else
-                let matchCount = Int(gt.gl_matchc)
-                #endif
-                for i in 0..<matchCount {
-                    let path = String.init(cString: gt.gl_pathv[i]!)
-                    results.append(path)
-                }
+        for pattern in patterns where executeGlob(pattern: pattern, gt: &gt) {
+            #if os(Linux)
+            let matchCount = Int(gt.gl_pathc)
+            #else
+            let matchCount = Int(gt.gl_matchc)
+            #endif
+            for i in 0..<matchCount {
+                let path = String.init(cString: gt.gl_pathv[i]!)
+                results.append(path)
             }
         }
         return Set(results.map(URL.init(fileURLWithPath: )))


### PR DESCRIPTION
In SwiftPM Plugin, a process cannot write a file even at tmp dir. This option allows users to specify a writable path.
