### PR TITLE
Build with Xcode16

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,61 +1,60 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "IBDecodable",
-        "repositoryURL": "https://github.com/IBDecodable/IBDecodable.git",
-        "state": {
-          "branch": null,
-          "revision": "d36937a8ba23252d2ffab48472605935c9c65477",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "SourceKitten",
-        "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
-        "state": {
-          "branch": null,
-          "revision": "558628392eb31d37cb251cfe626c53eafd330df6",
-          "version": "0.31.1"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser",
-        "state": {
-          "branch": null,
-          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
-          "version": "1.0.3"
-        }
-      },
-      {
-        "package": "SWXMLHash",
-        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
-        "state": {
-          "branch": null,
-          "revision": "9183170d20857753d4f331b0ca63f73c60764bf3",
-          "version": "5.0.2"
-        }
-      },
-      {
-        "package": "XcodeProjKit",
-        "repositoryURL": "https://github.com/phimage/XcodeProjKit.git",
-        "state": {
-          "branch": null,
-          "revision": "680db38d06462f9242a789d529a3e2a75c882365",
-          "version": "2.3.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-          "version": "4.0.6"
-        }
+  "originHash" : "a8f5f9d49113201814b3c5ada032a1f1cc0ffb2c401dca4ae13b1d7a8241c792",
+  "pins" : [
+    {
+      "identity" : "ibdecodable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/IBDecodable/IBDecodable.git",
+      "state" : {
+        "revision" : "0ae1b9e7a297ac015cce3febf4c6b5c98474a823",
+        "version" : "0.6.1"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "fbd6bbcddffa97dca4b8a6b5d5a8246a430be9c7",
+        "version" : "0.36.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
+        "version" : "7.0.2"
+      }
+    },
+    {
+      "identity" : "xcodeprojkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/phimage/XcodeProjKit.git",
+      "state" : {
+        "revision" : "680db38d06462f9242a789d529a3e2a75c882365",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "3036ba9d69cf1fd04d433527bc339dc0dc75433d",
+        "version" : "5.1.3"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.10
 
 import PackageDescription
 
 var package = Package(
     name: "IBLinter",
-    platforms: [.macOS(.v10_13)],
+    platforms: [.macOS(.v12)],
     products: [
         .executable(
             name: "iblinter", targets: ["IBLinter"]
@@ -22,7 +22,7 @@ var package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBDecodable/IBDecodable.git", from: "0.5.0"),
-        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.29.0"),
+        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.36.0"),
         .package(url: "https://github.com/phimage/XcodeProjKit.git", from: "2.2.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     ],


### PR DESCRIPTION
## Describe your changes
- I updated SourceKitten to 0.36.0, and can now build with Xcode 16.
  - Could not build IBLinter with Xcode 16 and got compile errors in SourceKitten.

<img width="701" alt="スクリーンショット 2024-10-17 22 02 17" src="https://github.com/user-attachments/assets/f843b629-0886-4480-87d2-da4a95d56130">

## Issue ticket number and link
- Close #189 
